### PR TITLE
Fixes typos & clarity on last page of Introduction

### DIFF
--- a/src/main/resources/assets/iceandfire/lang/bestiary/en_US/introduction_2.txt
+++ b/src/main/resources/assets/iceandfire/lang/bestiary/en_US/introduction_2.txt
@@ -1,14 +1,13 @@
     Once a lectern has been placed,
 it can be interacted with by
-clicking on it. The inside will
-have three slots, the leftmost
-for bestiaries, the bottom for
-manuscripts, and the leftmost
-for output bestiaries. For
-every three manuscripts, a new
-page will appear in the index
-of the bestiary. These new
-pages can range from
+right clicking on it. The inside 
+will have three slots, the leftmost
+for an input bestiary, the bottom 
+for manuscripts, and the rightmost
+for the output bestiary. For
+every manuscript, a new
+index will appear in the bestiary. 
+These new pages can be
 information about mythical
 creatures, different types
 of peoples, informative


### PR DESCRIPTION
Corrected 'leftmost' in reference to the output slot to 'rightmost'.
Corrected 'every three manuscripts' to 'every manuscript' to match current in game function as tested 7/29/2017 using version 1.0.1 for 1.10.2
Changed input bestiaries to singular indefinite to help indicate that each player will only want one, but many may exist.
Changed output bestiaries to singular definite to indicate only one will upgrade at a time.
Improved grammar for teaser of bestiary entry types.