### PR TITLE
Fixed dragonscale repair recipes

### DIFF
--- a/src/main/java/com/github/alexthe666/iceandfire/core/ModRecipes.java
+++ b/src/main/java/com/github/alexthe666/iceandfire/core/ModRecipes.java
@@ -101,14 +101,7 @@ public class ModRecipes {
 		ModItems.boneTools.setRepairItem(new ItemStack(ModItems.witherbone));
 		ModItems.fireBoneTools.setRepairItem(new ItemStack(ModItems.witherbone));
 		ModItems.iceBoneTools.setRepairItem(new ItemStack(ModItems.witherbone));
-		EnumDragonArmor.armor_green.material.setRepairItem(new ItemStack(ModItems.dragonscales_green));
-		EnumDragonArmor.armor_blue.material.setRepairItem(new ItemStack(ModItems.dragonscales_blue));
-		EnumDragonArmor.armor_bronze.material.setRepairItem(new ItemStack(ModItems.dragonscales_bronze));
-		EnumDragonArmor.armor_gray.material.setRepairItem(new ItemStack(ModItems.dragonscales_gray));
-		EnumDragonArmor.armor_red.material.setRepairItem(new ItemStack(ModItems.dragonscales_red));
-		EnumDragonArmor.armor_sapphire.material.setRepairItem(new ItemStack(ModItems.dragonscales_sapphire));
-		EnumDragonArmor.armor_silver.material.setRepairItem(new ItemStack(ModItems.dragonscales_silver));
-		EnumDragonArmor.armor_white.material.setRepairItem(new ItemStack(ModItems.dragonscales_white));
+		ModItems.dragon.setRepairItem(new ItemStack(ModItems.dragonbone));
 	}
 
 	public static BannerPattern addBanner(String name, ItemStack craftingStack) {


### PR DESCRIPTION
They should no longer crash, but however, due to my implementation, I had to use a material separate from dragon scales for the repair item. If you can think of a better item, let me know.

![i565 cimgpsh_orig](https://user-images.githubusercontent.com/5614902/31044989-4a90c1c2-a5a8-11e7-847b-41a2450b48fe.png)
