### PR TITLE
Fixed golden hippogryph armor recipe

### DIFF
--- a/src/main/resources/assets/iceandfire/recipes/gold_hippogryph_armor.json
+++ b/src/main/resources/assets/iceandfire/recipes/gold_hippogryph_armor.json
@@ -11,7 +11,7 @@
       "ore": "feather"
     },
     "D": {
-      "item": "minecraft:gold_horse_armor",
+      "item": "minecraft:golden_horse_armor",
       "data": 0
     }
   },


### PR DESCRIPTION
This fixes a minor typo that was preventing the crafting of golden hippogryph armor