### PR TITLE
Make the Gorgon cease to petrify blacklisted Entities

### DIFF
--- a/src/main/java/com/github/alexthe666/iceandfire/entity/EntityGorgon.java
+++ b/src/main/java/com/github/alexthe666/iceandfire/entity/EntityGorgon.java
@@ -92,7 +92,7 @@ public class EntityGorgon extends EntityMob implements IAnimatedEntity {
 			@Override
 			public boolean apply(@Nullable Entity entity) {
 				StoneEntityProperties properties = EntityPropertiesHandler.INSTANCE.getProperties(entity, StoneEntityProperties.class);
-				return entity instanceof EntityLiving && !(entity instanceof IBlacklistedFromStatues) || (properties == null || properties != null && !properties.isStone);
+				return entity instanceof EntityLiving && !(entity instanceof IBlacklistedFromStatues) && (properties == null || properties != null && !properties.isStone);
 			}
 		}));
 		this.tasks.removeTask(aiMelee);


### PR DESCRIPTION
With the `||` operator in the predicate for `EntityAINearestAttackableTarget` targeting `EntityLiving`, the previous instanceof check for `IBlacklistedFromStatues` is not taken into account as the operator makes it check that the Entity either isn't an instance of `IBlacklistedFromStatues` or either doesn't have any stone entity properties, or doesn't have the `isStone` flag set to true, rather than checking the property status on non-blacklisted Entities.