### PR TITLE
Fix DragonSkull moving on chunk load.

### DIFF
--- a/src/main/java/com/github/alexthe666/iceandfire/client/render/entity/RenderDragonSkull.java
+++ b/src/main/java/com/github/alexthe666/iceandfire/client/render/entity/RenderDragonSkull.java
@@ -21,7 +21,7 @@ public class RenderDragonSkull extends RenderLiving {
 		if (par1EntityLivingBase instanceof EntityDragonSkull) {
 			GL11.glScalef(((EntityDragonSkull) par1EntityLivingBase).getDragonSize(), 1, ((EntityDragonSkull) par1EntityLivingBase).getDragonSize());
 			GL11.glScalef(1, -((EntityDragonSkull) par1EntityLivingBase).getDragonSize(), 1);
-			GL11.glRotatef(par1EntityLivingBase.rotationYaw, 0, 1, 0);
+			GL11.glRotatef(((EntityDragonSkull) par1EntityLivingBase).getYaw(), 0, 1, 0);
 			super.preRenderCallback(par1EntityLivingBase, par2);
 		}
 

--- a/src/main/java/com/github/alexthe666/iceandfire/entity/EntityDragonSkull.java
+++ b/src/main/java/com/github/alexthe666/iceandfire/entity/EntityDragonSkull.java
@@ -21,6 +21,8 @@ public class EntityDragonSkull extends EntityAnimal implements IBlacklistedFromS
 	private static final DataParameter<Integer> DRAGON_TYPE = EntityDataManager.<Integer>createKey(EntityDragonSkull.class, DataSerializers.VARINT);
 	private static final DataParameter<Integer> DRAGON_AGE = EntityDataManager.<Integer>createKey(EntityDragonSkull.class, DataSerializers.VARINT);
 	private static final DataParameter<Integer> DRAGON_STAGE = EntityDataManager.<Integer>createKey(EntityDragonSkull.class, DataSerializers.VARINT);
+	private static final DataParameter<Float> DRAGON_DIRECTION = EntityDataManager.<Float>createKey(EntityDragonSkull.class, DataSerializers.FLOAT);
+
 	public final float minSize = 0.3F;
 	public final float maxSize = 8.58F;
 
@@ -54,7 +56,15 @@ public class EntityDragonSkull extends EntityAnimal implements IBlacklistedFromS
 		this.getDataManager().register(DRAGON_TYPE, 0);
 		this.getDataManager().register(DRAGON_AGE, 0);
 		this.getDataManager().register(DRAGON_STAGE, 0);
+		this.getDataManager().register(DRAGON_DIRECTION, 0.0f);
+	}
 
+	public float getYaw() {
+		return this.getDataManager().get(DRAGON_DIRECTION);
+	}
+
+	public void setYaw(float var1) {
+		this.getDataManager().set(DRAGON_DIRECTION, var1);
 	}
 
 	public int getType() {
@@ -106,7 +116,7 @@ public class EntityDragonSkull extends EntityAnimal implements IBlacklistedFromS
 	@Override
 	public boolean processInteract(EntityPlayer player, EnumHand hand) {
 		if (player.isSneaking()) {
-			this.rotationYaw = player.rotationYaw;
+			this.setYaw(player.rotationYaw);
 		}
 		return super.processInteract(player, hand);
 	}
@@ -116,6 +126,7 @@ public class EntityDragonSkull extends EntityAnimal implements IBlacklistedFromS
 		this.setType(compound.getInteger("Type"));
 		this.setStage(compound.getInteger("Stage"));
 		this.setDragonAge(compound.getInteger("DragonAge"));
+		this.setYaw(compound.getFloat("DragonYaw"));
 		super.readEntityFromNBT(compound);
 	}
 
@@ -124,6 +135,7 @@ public class EntityDragonSkull extends EntityAnimal implements IBlacklistedFromS
 		compound.setInteger("Type", this.getType());
 		compound.setInteger("Stage", this.getStage());
 		compound.setInteger("DragonAge", this.getDragonAge());
+		compound.setFloat("DragonYaw", this.getYaw());
 		super.writeEntityToNBT(compound);
 	}
 

--- a/src/main/java/com/github/alexthe666/iceandfire/item/ItemDragonBow.java
+++ b/src/main/java/com/github/alexthe666/iceandfire/item/ItemDragonBow.java
@@ -17,7 +17,7 @@ import net.minecraft.world.World;
 import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
 
-public class ItemDragonBow extends Item {
+public class ItemDragonBow extends ItemBow {
 
 	public ItemDragonBow() {
 		this.maxStackSize = 1;

--- a/src/main/java/com/github/alexthe666/iceandfire/item/ItemDragonBow.java
+++ b/src/main/java/com/github/alexthe666/iceandfire/item/ItemDragonBow.java
@@ -17,7 +17,7 @@ import net.minecraft.world.World;
 import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
 
-public class ItemDragonBow extends ItemBow {
+public class ItemDragonBow extends Item {
 
 	public ItemDragonBow() {
 		this.maxStackSize = 1;

--- a/src/main/java/com/github/alexthe666/iceandfire/item/ItemDragonSkull.java
+++ b/src/main/java/com/github/alexthe666/iceandfire/item/ItemDragonSkull.java
@@ -82,7 +82,7 @@ public class ItemDragonSkull extends Item {
 				skull.setStage(stack.getTagCompound().getInteger("Stage"));
 				skull.setDragonAge(stack.getTagCompound().getInteger("DragonAge"));
 				skull.setLocationAndAngles(pos.getX() + 0.5, pos.getY() + 1, pos.getZ() + 0.5, 0, 0);
-				skull.rotationYaw = player.rotationYaw;
+				skull.setYaw(player.rotationYaw);
 
 				if (!worldIn.isRemote) {
 					worldIn.spawnEntity(skull);


### PR DESCRIPTION
Use a new Yaw parameter stored in NBT. Fix skull taking random yaw when the chunk is loaded. This enable to use the skull as its primary goal, decoration.

EDIT : Fix dragon bow enchants & revert commit are useless, cause I made a mistake when pushing those, as they were added directly to this pull request. Read : just a fail from me.