### PR TITLE
Fix endless loops in Siren Island generation

### DIFF
--- a/src/main/java/com/github/alexthe666/iceandfire/structures/WorldGenSirenIsland.java
+++ b/src/main/java/com/github/alexthe666/iceandfire/structures/WorldGenSirenIsland.java
@@ -20,7 +20,7 @@ public class WorldGenSirenIsland extends WorldGenerator {
         int layer = 0;
         int sirens = 0;
         int sirensMax = 1 + rand.nextInt(3);
-        while(!worldIn.getBlockState(center).isOpaqueCube()){
+        while(!worldIn.getBlockState(center).isOpaqueCube() && center.getY() >= 0){
             layer++;
             for(float i = 0; i < getRadius(layer, up); i += 0.5) {
                 for (float j = 0; j < 2 * Math.PI * i + rand.nextInt(2); j += 0.5) {
@@ -39,7 +39,7 @@ public class WorldGenSirenIsland extends WorldGenerator {
         for(float i = 0; i < getRadius(layer, up); i += 0.5) {
             for (float j = 0; j < 2 * Math.PI * i + rand.nextInt(2); j += 0.5) {
                 BlockPos stonePos = new BlockPos(Math.floor(center.getX() + Math.sin(j) * i + rand.nextInt(2)), center.getY(), Math.floor(center.getZ() + Math.cos(j) * i + rand.nextInt(2)));
-                while(!worldIn.getBlockState(stonePos).isOpaqueCube()){
+                while(!worldIn.getBlockState(stonePos).isOpaqueCube() && stonePos.getY() >= 0){
                     worldIn.setBlockState(stonePos, getStone(rand), 3);
                     stonePos = stonePos.down();
                 }


### PR DESCRIPTION
The while loops did not exit when scanning below y-level 0.
This caused issues with Void type worlds that do not have a bottom layer,
e.g. the Compact Machines 3 dimension.

This should fix #656