### PR TITLE
Refactored some logic to skip unused computations

### DIFF
--- a/src/main/java/com/github/alexthe666/iceandfire/entity/EntityPixie.java
+++ b/src/main/java/com/github/alexthe666/iceandfire/entity/EntityPixie.java
@@ -387,9 +387,12 @@ public class EntityPixie extends EntityTameable {
 		}
 
 		public boolean shouldExecute() {
-			BlockPos blockpos1 = findAHouse(EntityPixie.this, EntityPixie.this.world);
+			if (EntityPixie.this.isOwnerClose() || EntityPixie.this.getMoveHelper().isUpdating() || EntityPixie.this.isSitting() || EntityPixie.this.rand.nextInt(20) != 0 || EntityPixie.this.ticksUntilHouseAI != 0) {
+				return false;
+			}
 
-			return !EntityPixie.this.isOwnerClose() && !EntityPixie.this.isSitting() && !EntityPixie.this.getMoveHelper().isUpdating() && EntityPixie.this.rand.nextInt(20) == 0 && EntityPixie.this.ticksUntilHouseAI == 0 && !blockpos1.toString().equals(EntityPixie.this.getPosition().toString());
+			BlockPos blockpos1 = findAHouse(EntityPixie.this, EntityPixie.this.world);
+			return !blockpos1.toString().equals(EntityPixie.this.getPosition().toString());
 		}
 
 		public boolean shouldContinueExecuting() {

--- a/src/main/java/com/github/alexthe666/iceandfire/event/EventLiving.java
+++ b/src/main/java/com/github/alexthe666/iceandfire/event/EventLiving.java
@@ -258,11 +258,11 @@ public class EventLiving {
 			}
 		}
 
-		SirenEntityProperties sirenProps = EntityPropertiesHandler.INSTANCE.getProperties(event.getEntityLiving(), SirenEntityProperties.class);
-		if(sirenProps != null) {
-			EntitySiren closestSiren = sirenProps.getClosestSiren(event.getEntityLiving().world, event.getEntityLiving());
-			if (event.getEntityLiving() instanceof EntityPlayer || event.getEntityLiving() instanceof EntityVillager || event.getEntityLiving() instanceof IHearsSiren) {
-				if (sirenProps != null && closestSiren != null && closestSiren.isActuallySinging()) {
+		if (event.getEntityLiving() instanceof EntityPlayer || event.getEntityLiving() instanceof EntityVillager || event.getEntityLiving() instanceof IHearsSiren) {
+			SirenEntityProperties sirenProps = EntityPropertiesHandler.INSTANCE.getProperties(event.getEntityLiving(), SirenEntityProperties.class);
+			if (sirenProps != null) {
+				EntitySiren closestSiren = sirenProps.getClosestSiren(event.getEntityLiving().world, event.getEntityLiving());
+				if (closestSiren != null && closestSiren.isActuallySinging()) {
 					stepHeightSwitched = false;
 					if (EntitySiren.isWearingEarplugs(event.getEntityLiving())) {
 						sirenProps.isCharmed = false;
@@ -317,12 +317,13 @@ public class EventLiving {
 							sirenProps.isCharmed = false;
 						}
 					}
-				} else if (sirenProps != null && !sirenProps.isCharmed && !stepHeightSwitched) {
+				} else if (!sirenProps.isCharmed && !stepHeightSwitched) {
 					event.getEntityLiving().stepHeight = 0.6F;
 					stepHeightSwitched = true;
 				}
 			}
 		}
+
 		if (event.getEntityLiving() instanceof EntityLiving) {
 			boolean stonePlayer = event.getEntityLiving() instanceof EntityStoneStatue;
 			StoneEntityProperties properties = EntityPropertiesHandler.INSTANCE.getProperties(event.getEntityLiving(), StoneEntityProperties.class);


### PR DESCRIPTION
Here's a couple of small changes which hopefully leave the mod behavior unchanged but skip two expensive calculations (a Pixie's search for a house and an entity's search for the nearest Siren) when the results won't be used.

From messing about with VisualVM and doing before/after comparisons with /forge tps these each seemed to cut about 2ms or more off the server tick time in a single player world.  (For the Pixie one this was while standing in a Pixie village.)

