### PR TITLE
Skip Gorgon AI in setAttackTarget on client.

### DIFF
--- a/src/main/java/com/github/alexthe666/iceandfire/entity/EntityGorgon.java
+++ b/src/main/java/com/github/alexthe666/iceandfire/entity/EntityGorgon.java
@@ -125,7 +125,7 @@ public class EntityGorgon extends EntityMob implements IAnimatedEntity, IVillage
 
 	public void setAttackTarget(@Nullable EntityLivingBase entitylivingbaseIn) {
 		super.setAttackTarget(entitylivingbaseIn);
-		if (entitylivingbaseIn != null) {
+		if (entitylivingbaseIn != null && !world.isRemote) {
 			boolean blindness = this.isPotionActive(MobEffects.BLINDNESS) || entitylivingbaseIn.isPotionActive(MobEffects.BLINDNESS) || entitylivingbaseIn instanceof IBlacklistedFromStatues && !((IBlacklistedFromStatues) entitylivingbaseIn).canBeTurnedToStone();
 			if (blindness) {
 				this.tasks.removeTask(aiStare);


### PR DESCRIPTION
Don't try to do AI updates in EntityGorgon.setAttackTarget unless running on server.
This resolves an incompatibility with Pneumaticraft: Repressurized.  Fixes #1046.