### PR TITLE
Check isDead before drop item

### DIFF
--- a/src/main/java/com/github/alexthe666/iceandfire/entity/EntityDragonEgg.java
+++ b/src/main/java/com/github/alexthe666/iceandfire/entity/EntityDragonEgg.java
@@ -167,7 +167,7 @@ public class EntityDragonEgg extends EntityLiving implements IBlacklistedFromSta
 
     @Override
     public boolean attackEntityFrom(DamageSource var1, float var2) {
-        if (!world.isRemote && !var1.canHarmInCreative()) {
+        if (!world.isRemote && !var1.canHarmInCreative() && !isDead) {
             this.dropItem(this.getItem().getItem(), 1);
         }
         this.setDead();

--- a/src/main/java/com/github/alexthe666/iceandfire/entity/EntityDragonSkull.java
+++ b/src/main/java/com/github/alexthe666/iceandfire/entity/EntityDragonSkull.java
@@ -103,6 +103,8 @@ public class EntityDragonSkull extends EntityAnimal implements IBlacklistedFromS
 	}
 
 	public void turnIntoItem() {
+		if (isDead)
+			return;
 		this.setDead();
 		ItemStack stack = new ItemStack(ModItems.dragon_skull, 1, getType());
 		stack.setTagCompound(new NBTTagCompound());


### PR DESCRIPTION
EntityDragonEgg drop double items when mod ToughAsNails is installed and hit the entity in survival mode.
That is due to ToughAsNails called `target.attackEntityFrom` on handling `AttackEntityEvent`.
So the `attackEntityFrom` is called twice on a single hit. I prefer to check `isDead` before drop item to fix this.