### PR TITLE
Fix Myrmex Server Freezing

### DIFF
--- a/src/main/java/com/github/alexthe666/iceandfire/entity/MyrmexHive.java
+++ b/src/main/java/com/github/alexthe666/iceandfire/entity/MyrmexHive.java
@@ -102,7 +102,7 @@ public class MyrmexHive {
 
     public static BlockPos getGroundedPos(World world, BlockPos pos) {
         BlockPos current = pos;
-        while(world.isAirBlock(current.down())){
+        while(world.isAirBlock(current.down()) && current.getY() > 0){
             current = current.down();
         }
         return current;


### PR DESCRIPTION
It looks like in some weird cases `getGroundedPos` gets called on columns where no block is present from y 0-255. 
This then causes the server to freeze as this while loop infinitely tries to check blocks below, even in positions below 0.

Sample Stack Trace:
```
java.lang.Thread.State: RUNNABLE
    at net.minecraft.block.state.BlockStateContainer$StateImplementation.func_185904_a(BlockStateContainer.java:294)
    at net.minecraft.block.Block.isAir(Block.java:1142)
    at net.minecraft.world.World.func_175623_d(World.java:230)
    at com.github.alexthe666.iceandfire.entity.MyrmexHive.getGroundedPos(MyrmexHive.java:105)
    at com.github.alexthe666.iceandfire.entity.ai.MyrmexAILeaveHive.func_75250_a(MyrmexAILeaveHive.java:32)
    at net.minecraft.entity.ai.EntityAITasks.func_75774_a(SourceFile:94)
    at net.minecraft.entity.EntityLiving.func_70626_be(EntityLiving.java:763)
    at net.minecraft.entity.EntityLivingBase.func_70636_d(EntityLivingBase.java:2351)
    at net.minecraft.entity.EntityLiving.func_70636_d(EntityLiving.java:577)
    at net.minecraft.entity.EntityAgeable.func_70636_d(EntityAgeable.java:178)
    at net.minecraft.entity.passive.EntityAnimal.func_70636_d(SourceFile:43)
    at com.github.alexthe666.iceandfire.entity.EntityMyrmexWorker.func_70636_d(EntityMyrmexWorker.java:56)
    at net.minecraft.entity.EntityLivingBase.func_70071_h_(EntityLivingBase.java:2171)
    at net.minecraft.entity.EntityLiving.func_70071_h_(EntityLiving.java:295)
    at com.github.alexthe666.iceandfire.entity.EntityMyrmexBase.func_70071_h_(EntityMyrmexBase.java:177)
    at org.spongepowered.common.event.tracking.TrackingUtil.tickEntity(TrackingUtil.java:157)
    at net.minecraft.world.WorldServer.redirect$onCallEntityUpdate$zma000(WorldServer.java:2982)
    at net.minecraft.world.World.func_72866_a(World.java:4157)
    at net.minecraft.world.WorldServer.func_72866_a(WorldServer.java:832)
    at net.minecraft.world.World.func_72870_g(World.java:7913)
    at net.minecraft.world.World.func_72939_s(World.java:6605)
    at net.minecraft.world.WorldServer.func_72939_s(WorldServer.java:2295)
    at net.minecraft.server.MinecraftServer.func_71190_q(MinecraftServer.java:767)
    at net.minecraft.server.dedicated.DedicatedServer.func_71190_q(DedicatedServer.java:397)
    at net.minecraft.server.MinecraftServer.func_71217_p(MinecraftServer.java:668)
    at net.minecraft.server.MinecraftServer.run(MinecraftServer.java:526)
    at java.lang.Thread.run(Thread.java:748) 
```