### PR TITLE
Fixes #1517, #1520, #1521, #1522, #1529, #1532, #1549

### DIFF
--- a/src/main/java/com/github/alexthe666/iceandfire/CommonProxy.java
+++ b/src/main/java/com/github/alexthe666/iceandfire/CommonProxy.java
@@ -6,6 +6,7 @@ import com.github.alexthe666.iceandfire.block.BlockPixieHouse;
 import com.github.alexthe666.iceandfire.block.BlockPodium;
 import com.github.alexthe666.iceandfire.core.ModBlocks;
 import com.github.alexthe666.iceandfire.core.ModItems;
+import com.github.alexthe666.iceandfire.core.ModRecipes;
 import com.github.alexthe666.iceandfire.core.ModSounds;
 import com.github.alexthe666.iceandfire.entity.*;
 import com.github.alexthe666.iceandfire.enums.EnumDragonArmor;
@@ -140,7 +141,8 @@ public class CommonProxy {
     }
 
     @SubscribeEvent
-    public static void registerItemBlocks(RegistryEvent.Register<Item> event) {
+    public static void registerItems(RegistryEvent.Register<Item> event) {
+        // ItemBlocks
         try {
             for (Field f : ModBlocks.class.getDeclaredFields()) {
                 Object obj = f.get(null);
@@ -175,10 +177,8 @@ public class CommonProxy {
             itemBlock.setRegistryName(color.scaleBlock.getRegistryName());
             event.getRegistry().register(itemBlock);
         }
-    }
 
-    @SubscribeEvent
-    public static void registerItems(RegistryEvent.Register<Item> event) {
+        // Items
         try {
             for (Field f : ModItems.class.getDeclaredFields()) {
                 Object obj = f.get(null);
@@ -216,6 +216,8 @@ public class CommonProxy {
             event.getRegistry().register(troll.leggings);
             event.getRegistry().register(troll.boots);
         }
+
+        ModRecipes.preInit();
     }
 
     @SubscribeEvent

--- a/src/main/java/com/github/alexthe666/iceandfire/IceAndFire.java
+++ b/src/main/java/com/github/alexthe666/iceandfire/IceAndFire.java
@@ -84,7 +84,6 @@ public class IceAndFire {
         ThaumcraftCompatBridge.loadThaumcraftCompat();
         LootFunctionManager.registerFunction(new CustomizeToDragon.Serializer());
         LootFunctionManager.registerFunction(new CustomizeToSeaSerpent.Serializer());
-        ModRecipes.preInit();
     }
 
 


### PR DESCRIPTION
The oredict registration should happen after registering items, so it was moved there.

Additionally, registerItems and registerItemBlocks seemed to be called in random order, so there was need to merge them together (it could be handled differently, but this seemed like the simplest solution).

The method preInit() in ModRecipes might require renaming if you decide that it's not fitting.

After committing the changes I've noticed that this fixes #1522 and #1532 as well, so I've included them in pull request title.

(It looks like I accidentally messed up my previous PR, sorry for making the mess.)