### PR TITLE
Do not spawn client-side particles with the server's world

### DIFF
--- a/src/main/java/com/github/alexthe666/iceandfire/ClientProxy.java
+++ b/src/main/java/com/github/alexthe666/iceandfire/ClientProxy.java
@@ -324,8 +324,15 @@ public class ClientProxy extends CommonProxy {
 	}
 
 	@SideOnly(Side.CLIENT)
-	public void spawnParticle(String name, World world, double x, double y, double z, double motX, double motY, double motZ, float size) {
+	public void spawnParticle(String name, double x, double y, double z, double motX, double motY, double motZ, float size) {
 		net.minecraft.client.particle.Particle particle = null;
+
+		World world = Minecraft.getMinecraft().world;
+
+		if (world == null) {
+			return;
+		}
+
 		if (name.equals("dragonfire")) {
 			particle = new ParticleDragonFlame(world, x, y, z, motX, motY, motZ, size);
 			if (world.rand.nextFloat() > 0.95F) {

--- a/src/main/java/com/github/alexthe666/iceandfire/CommonProxy.java
+++ b/src/main/java/com/github/alexthe666/iceandfire/CommonProxy.java
@@ -240,14 +240,14 @@ public class CommonProxy {
     public void postRender() {
     }
 
-    public void spawnParticle(String name, World world, double x, double y, double z, double motX, double motY, double motZ) {
-        spawnParticle(name, world, x, y, z, motX, motY, motZ, 1.0F);
+    public void spawnParticle(String name, double x, double y, double z, double motX, double motY, double motZ) {
+        spawnParticle(name, x, y, z, motX, motY, motZ, 1.0F);
     }
 
     public void spawnDragonParticle(String name, World world, double x, double y, double z, double motX, double motY, double motZ, EntityDragonBase entityDragonBase) {
     }
 
-    public void spawnParticle(String name, World world, double x, double y, double z, double motX, double motY, double motZ, float size) {
+    public void spawnParticle(String name, double x, double y, double z, double motX, double motY, double motZ, float size) {
     }
 
     public void openBestiaryGui(ItemStack book) {

--- a/src/main/java/com/github/alexthe666/iceandfire/entity/EntityDragonBase.java
+++ b/src/main/java/com/github/alexthe666/iceandfire/entity/EntityDragonBase.java
@@ -61,7 +61,6 @@ import net.minecraftforge.fml.common.FMLCommonHandler;
 import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
 import net.minecraftforge.items.ItemStackHandler;
-import org.lwjgl.Sys;
 
 import javax.annotation.Nullable;
 import java.util.List;
@@ -415,7 +414,7 @@ public abstract class EntityDragonBase extends EntityTameable implements IMultip
                         this.world.spawnParticle(EnumParticleTypes.FLAME, this.posX + (double) (this.rand.nextFloat() * this.width * 2.0F) - (double) this.width, this.posY + (double) (this.rand.nextFloat() * this.height), this.posZ + (double) (this.rand.nextFloat() * this.width * 2.0F) - (double) this.width, d2, d0, d1, new int[0]);
                     }
                 } else {
-                    IceAndFire.PROXY.spawnParticle("snowflake", this.world, this.posX + (double) (this.rand.nextFloat() * this.width * 2.0F) - (double) this.width, this.posY + (double) (this.rand.nextFloat() * this.height), this.posZ + (double) (this.rand.nextFloat() * this.width * 2.0F) - (double) this.width, d2, d0, d1);
+                    IceAndFire.PROXY.spawnParticle("snowflake", this.posX + (double) (this.rand.nextFloat() * this.width * 2.0F) - (double) this.width, this.posY + (double) (this.rand.nextFloat() * this.height), this.posZ + (double) (this.rand.nextFloat() * this.width * 2.0F) - (double) this.width, d2, d0, d1);
                 }
             }
         }
@@ -1485,7 +1484,7 @@ public abstract class EntityDragonBase extends EntityTameable implements IMultip
                 if (this.isFire && world.isRemote) {
                     this.world.spawnParticle(EnumParticleTypes.SMOKE_LARGE, headPosX, headPosY, headPosZ, 0, 0, 0);
                 } else if (world.isRemote) {
-                    IceAndFire.PROXY.spawnParticle("dragonice", this.world, headPosX, headPosY, headPosZ, 0, 0, 0);
+                    IceAndFire.PROXY.spawnParticle("dragonice", headPosX, headPosY, headPosZ, 0, 0, 0);
                 }
             }
             if (this.isFire) {

--- a/src/main/java/com/github/alexthe666/iceandfire/entity/EntityDragonFire.java
+++ b/src/main/java/com/github/alexthe666/iceandfire/entity/EntityDragonFire.java
@@ -48,7 +48,7 @@ public class EntityDragonFire extends EntityFireball implements IDragonProjectil
 	public void onUpdate() {
 		super.onUpdate();
 		for (int i = 0; i < 6; ++i) {
-			IceAndFire.PROXY.spawnParticle("dragonfire", world, this.posX, this.posY, this.posZ, 0.0D, 0.0D, 0.0D);
+			IceAndFire.PROXY.spawnParticle("dragonfire", this.posX, this.posY, this.posZ, 0.0D, 0.0D, 0.0D);
 		}
 		if (ticksExisted > 160) {
 			setDead();

--- a/src/main/java/com/github/alexthe666/iceandfire/entity/EntityDragonIceCharge.java
+++ b/src/main/java/com/github/alexthe666/iceandfire/entity/EntityDragonIceCharge.java
@@ -55,7 +55,7 @@ public class EntityDragonIceCharge extends EntityFireball implements IDragonProj
 
 	public void onUpdate() {
 		for (int i = 0; i < 14; ++i) {
-			IceAndFire.PROXY.spawnParticle("snowflake", world, this.posX + this.rand.nextDouble() * 1 * (this.rand.nextBoolean() ? -1 : 1), this.posY + this.rand.nextDouble() * 1 * (this.rand.nextBoolean() ? -1 : 1), this.posZ + this.rand.nextDouble() * 1 * (this.rand.nextBoolean() ? -1 : 1), 0.0D, 0.0D, 0.0D);
+			IceAndFire.PROXY.spawnParticle("snowflake", this.posX + this.rand.nextDouble() * 1 * (this.rand.nextBoolean() ? -1 : 1), this.posY + this.rand.nextDouble() * 1 * (this.rand.nextBoolean() ? -1 : 1), this.posZ + this.rand.nextDouble() * 1 * (this.rand.nextBoolean() ? -1 : 1), 0.0D, 0.0D, 0.0D);
 		}
 		if (this.world.isRemote || (this.shootingEntity == null || !this.shootingEntity.isDead) && this.world.isBlockLoaded(new BlockPos(this))) {
 			super.onUpdate();

--- a/src/main/java/com/github/alexthe666/iceandfire/entity/EntityDragonIceProjectile.java
+++ b/src/main/java/com/github/alexthe666/iceandfire/entity/EntityDragonIceProjectile.java
@@ -48,7 +48,7 @@ public class EntityDragonIceProjectile extends EntityFireball implements IDragon
 	public void onUpdate() {
 		super.onUpdate();
 		for (int i = 0; i < 6; ++i) {
-			IceAndFire.PROXY.spawnParticle("dragonice", world, this.posX, this.posY, this.posZ, 0.0D, 0.0D, 0.0D);
+			IceAndFire.PROXY.spawnParticle("dragonice", this.posX, this.posY, this.posZ, 0.0D, 0.0D, 0.0D);
 		}
 		if (ticksExisted > 160) {
 			setDead();

--- a/src/main/java/com/github/alexthe666/iceandfire/entity/EntityFireDragon.java
+++ b/src/main/java/com/github/alexthe666/iceandfire/entity/EntityFireDragon.java
@@ -403,7 +403,7 @@ public class EntityFireDragon extends EntityDragonBase {
                     double spawnY = burnY + (rand.nextFloat() * 3.0) - 1.5;
                     double spawnZ = burnZ + (rand.nextFloat() * 3.0) - 1.5;
                     for (int k = 0; k < 7; k++) {
-                        IceAndFire.PROXY.spawnParticle("dragonfire", world, spawnX, spawnY, spawnZ, 0, -0.1F, 0, particleScale * 2.75F);
+                        IceAndFire.PROXY.spawnParticle("dragonfire", spawnX, spawnY, spawnZ, 0, -0.1F, 0, particleScale * 2.75F);
                     }
                 }
             }
@@ -414,7 +414,7 @@ public class EntityFireDragon extends EntityDragonBase {
             double spawnY = burnY + (rand.nextFloat() * 3.0) - 1.5;
             double spawnZ = burnZ + (rand.nextFloat() * 3.0) - 1.5;
             for (int j = 0; j < 7; j++) {
-                IceAndFire.PROXY.spawnParticle("dragonfire", world, spawnX, spawnY, spawnZ, 0, -0.1F, 0, particleScale * 2.75F);
+                IceAndFire.PROXY.spawnParticle("dragonfire", spawnX, spawnY, spawnZ, 0, -0.1F, 0, particleScale * 2.75F);
             }
             FireExplosion explosion = new FireExplosion(world, this, spawnX, spawnY, spawnZ, Math.max(0.35F, this.getDragonStage() * 0.35F), true);
             explosion.doExplosionA();

--- a/src/main/java/com/github/alexthe666/iceandfire/entity/EntityGorgon.java
+++ b/src/main/java/com/github/alexthe666/iceandfire/entity/EntityGorgon.java
@@ -154,7 +154,7 @@ public class EntityGorgon extends EntityMob implements IAnimatedEntity, IVillage
 			double d2 = 0.4;
 			double d0 = 0.1;
 			double d1 = 0.1;
-			IceAndFire.PROXY.spawnParticle("blood", this.world, this.posX + (double) (this.rand.nextFloat() * this.width * 2.0F) - (double) this.width, this.posY, this.posZ + (double) (this.rand.nextFloat() * this.width * 2.0F) - (double) this.width, d2, d0, d1);
+			IceAndFire.PROXY.spawnParticle("blood", this.posX + (double) (this.rand.nextFloat() * this.width * 2.0F) - (double) this.width, this.posY, this.posZ + (double) (this.rand.nextFloat() * this.width * 2.0F) - (double) this.width, d2, d0, d1);
 		}
 		if (this.deathTime >= 200) {
 			if (!this.world.isRemote && (this.isPlayer() || this.recentlyHit > 0 && this.canDropLoot() && this.world.getGameRules().getBoolean("doMobLoot"))) {

--- a/src/main/java/com/github/alexthe666/iceandfire/entity/EntityIceDragon.java
+++ b/src/main/java/com/github/alexthe666/iceandfire/entity/EntityIceDragon.java
@@ -446,7 +446,7 @@ public class EntityIceDragon extends EntityDragonBase {
 			double progressZ = headPosZ + d4 * (i / (float) distance);
 			if(canPositionBeSeen(progressX, progressY, progressZ)){
 				if(world.isRemote && ticksExisted % 3 == 0){
-					IceAndFire.PROXY.spawnParticle("dragonfire", world, progressX, progressY, progressZ, 0, 0.15F, 0, particleScale);
+					IceAndFire.PROXY.spawnParticle("dragonfire", progressX, progressY, progressZ, 0, 0.15F, 0, particleScale);
 				}
 				for (EntityLivingBase entity : world.getEntitiesWithinAABB(EntityLivingBase.class, new AxisAlignedBB(progressX - 0.75D, progressY - 0.75D, progressZ - 0.75D, progressX + 0.75D, progressY + 0.75D, progressZ + 0.75D))) {
 					if (!this.isOnSameTeam(entity) && entity != this) {
@@ -468,7 +468,7 @@ public class EntityIceDragon extends EntityDragonBase {
 					double spawnY = burnY + (rand.nextFloat() * 3.0) - 1.5;
 					double spawnZ = burnZ + (rand.nextFloat() * 3.0) - 1.5;
 					for (int k = 0; k < 7; k++) {
-						IceAndFire.PROXY.spawnParticle("dragonice", world, spawnX, spawnY, spawnZ, 0, -0.1F, 0, particleScale * 2.75F);
+						IceAndFire.PROXY.spawnParticle("dragonice", spawnX, spawnY, spawnZ, 0, -0.1F, 0, particleScale * 2.75F);
 					}
 				}
 			}
@@ -479,7 +479,7 @@ public class EntityIceDragon extends EntityDragonBase {
 			double spawnY = burnY + (rand.nextFloat() * 3.0) - 1.5;
 			double spawnZ = burnZ + (rand.nextFloat() * 3.0) - 1.5;
 			for (int j = 0; j < 7; j++) {
-				IceAndFire.PROXY.spawnParticle("dragonice", world, spawnX, spawnY, spawnZ, 0, -0.1F, 0, particleScale * 2.75F);
+				IceAndFire.PROXY.spawnParticle("dragonice", spawnX, spawnY, spawnZ, 0, -0.1F, 0, particleScale * 2.75F);
 			}
 			IceExplosion explosion = new IceExplosion(world, this, spawnX, spawnY, spawnZ, Math.max(0.35F, this.getDragonStage() * 0.35F), true);
 			explosion.doExplosionA();

--- a/src/main/java/com/github/alexthe666/iceandfire/entity/EntityPixie.java
+++ b/src/main/java/com/github/alexthe666/iceandfire/entity/EntityPixie.java
@@ -244,7 +244,7 @@ public class EntityPixie extends EntityTameable {
 			this.moveHelper.action = EntityMoveHelper.Action.WAIT;
 		}
 		if(world.isRemote){
-			IceAndFire.PROXY.spawnParticle("if_pixie", this.world, this.posX + (double) (this.rand.nextFloat() * this.width * 2F) - (double) this.width, this.posY + (double) (this.rand.nextFloat() * this.height), this.posZ + (double) (this.rand.nextFloat() * this.width * 2F) - (double) this.width, PARTICLE_RGB[this.getColor()][0], PARTICLE_RGB[this.getColor()][1], PARTICLE_RGB[this.getColor()][2]);
+			IceAndFire.PROXY.spawnParticle("if_pixie", this.posX + (double) (this.rand.nextFloat() * this.width * 2F) - (double) this.width, this.posY + (double) (this.rand.nextFloat() * this.height), this.posZ + (double) (this.rand.nextFloat() * this.width * 2F) - (double) this.width, PARTICLE_RGB[this.getColor()][0], PARTICLE_RGB[this.getColor()][1], PARTICLE_RGB[this.getColor()][2]);
 		}
 		if (ticksUntilHouseAI > 0) {
 			ticksUntilHouseAI--;

--- a/src/main/java/com/github/alexthe666/iceandfire/entity/EntitySeaSerpentBubbles.java
+++ b/src/main/java/com/github/alexthe666/iceandfire/entity/EntitySeaSerpentBubbles.java
@@ -3,7 +3,6 @@ package com.github.alexthe666.iceandfire.entity;
 import com.github.alexthe666.iceandfire.IceAndFire;
 import net.minecraft.block.material.Material;
 import net.minecraft.entity.Entity;
-import net.minecraft.entity.item.EntityBoat;
 import net.minecraft.entity.projectile.EntityFireball;
 import net.minecraft.entity.projectile.ProjectileHelper;
 import net.minecraft.init.SoundEvents;
@@ -60,7 +59,7 @@ public class EntitySeaSerpentBubbles extends EntityFireball implements IDragonPr
 
             if (this.isInWater()) {
                 for (int i = 0; i < 6; ++i) {
-                    IceAndFire.PROXY.spawnParticle("serpent_bubble", world, this.posX, this.posY, this.posZ, 0.0D, 0.0D, 0.0D);
+                    IceAndFire.PROXY.spawnParticle("serpent_bubble", this.posX, this.posY, this.posZ, 0.0D, 0.0D, 0.0D);
                 }
             } else {
                 this.playSound(SoundEvents.ENTITY_ITEM_PICKUP, 1F, this.rand.nextFloat());

--- a/src/main/java/com/github/alexthe666/iceandfire/entity/EntitySiren.java
+++ b/src/main/java/com/github/alexthe666/iceandfire/entity/EntitySiren.java
@@ -20,7 +20,6 @@ import net.minecraft.entity.monster.EntityMob;
 import net.minecraft.entity.passive.EntityVillager;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.inventory.EntityEquipmentSlot;
-import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.network.datasync.DataParameter;
@@ -276,7 +275,7 @@ public class EntitySiren extends EntityMob implements IAnimatedEntity {
                 double extraX = (double) (radius * MathHelper.sin((float) (Math.PI + angle)));
                 double extraY = 1.2F;
                 double extraZ = (double) (radius * MathHelper.cos(angle));
-                IceAndFire.PROXY.spawnParticle("siren_music", this.world, this.posX + extraX + this.rand.nextFloat() - 0.5, this.posY + extraY + this.rand.nextFloat() - 0.5, this.posZ + extraZ + this.rand.nextFloat() - 0.5, 0, 0, 0);
+                IceAndFire.PROXY.spawnParticle("siren_music", this.posX + extraX + this.rand.nextFloat() - 0.5, this.posY + extraY + this.rand.nextFloat() - 0.5, this.posZ + extraZ + this.rand.nextFloat() - 0.5, 0, 0, 0);
             }
 
         }

--- a/src/main/java/com/github/alexthe666/iceandfire/entity/FireChargeExplosion.java
+++ b/src/main/java/com/github/alexthe666/iceandfire/entity/FireChargeExplosion.java
@@ -220,8 +220,8 @@ public class FireChargeExplosion extends Explosion {
 					d3 = d3 * d7;
 					d4 = d4 * d7;
 					d5 = d5 * d7;
-					IceAndFire.PROXY.spawnParticle("dragonice", worldObj, (d0 + this.explosionX) / 2.0D, (d1 + this.explosionY) / 2.0D, (d2 + this.explosionZ) / 2.0D, d3, d4, d5);
-					IceAndFire.PROXY.spawnParticle("dragonice", worldObj, d0, d1, d2, d3, d4, d5);
+					IceAndFire.PROXY.spawnParticle("dragonice", (d0 + this.explosionX) / 2.0D, (d1 + this.explosionY) / 2.0D, (d2 + this.explosionZ) / 2.0D, d3, d4, d5);
+					IceAndFire.PROXY.spawnParticle("dragonice", d0, d1, d2, d3, d4, d5);
 				}
 
 				if (iblockstate.getMaterial() != Material.AIR) {

--- a/src/main/java/com/github/alexthe666/iceandfire/entity/tile/TileEntityJar.java
+++ b/src/main/java/com/github/alexthe666/iceandfire/entity/tile/TileEntityJar.java
@@ -95,7 +95,7 @@ public class TileEntityJar extends TileEntity implements ITickable {
 	public void update() {
 		ticksExisted++;
 		if (this.hasPixie) {
-			IceAndFire.PROXY.spawnParticle("if_pixie", this.world, this.pos.getX() + 0.5F + (double) (this.rand.nextFloat() * PARTICLE_WIDTH * 2F) - (double) PARTICLE_WIDTH, this.pos.getY() + (double) (this.rand.nextFloat() * PARTICLE_HEIGHT), this.pos.getZ() + 0.5F + (double) (this.rand.nextFloat() * PARTICLE_WIDTH * 2F) - (double) PARTICLE_WIDTH, EntityPixie.PARTICLE_RGB[this.pixieType][0], EntityPixie.PARTICLE_RGB[this.pixieType][1], EntityPixie.PARTICLE_RGB[this.pixieType][2]);
+			IceAndFire.PROXY.spawnParticle("if_pixie", this.pos.getX() + 0.5F + (double) (this.rand.nextFloat() * PARTICLE_WIDTH * 2F) - (double) PARTICLE_WIDTH, this.pos.getY() + (double) (this.rand.nextFloat() * PARTICLE_HEIGHT), this.pos.getZ() + 0.5F + (double) (this.rand.nextFloat() * PARTICLE_WIDTH * 2F) - (double) PARTICLE_WIDTH, EntityPixie.PARTICLE_RGB[this.pixieType][0], EntityPixie.PARTICLE_RGB[this.pixieType][1], EntityPixie.PARTICLE_RGB[this.pixieType][2]);
 		}
 		if (ticksExisted % 24000 * 2 == 0 && !this.hasProduced && this.hasPixie && !this.getWorld().isRemote) {
 			this.hasProduced = true;

--- a/src/main/java/com/github/alexthe666/iceandfire/entity/tile/TileEntityPixieHouse.java
+++ b/src/main/java/com/github/alexthe666/iceandfire/entity/tile/TileEntityPixieHouse.java
@@ -84,7 +84,7 @@ public class TileEntityPixieHouse extends TileEntity implements ITickable {
 			releasePixie();
 		}
 		if (this.hasPixie) {
-			IceAndFire.PROXY.spawnParticle("if_pixie", this.world, this.pos.getX() + 0.5F + (double) (this.rand.nextFloat() * PARTICLE_WIDTH * 2F) - (double) PARTICLE_WIDTH, this.pos.getY() + (double) (this.rand.nextFloat() * PARTICLE_HEIGHT), this.pos.getZ() + 0.5F + (double) (this.rand.nextFloat() * PARTICLE_WIDTH * 2F) - (double) PARTICLE_WIDTH, EntityPixie.PARTICLE_RGB[this.pixieType][0], EntityPixie.PARTICLE_RGB[this.pixieType][1], EntityPixie.PARTICLE_RGB[this.pixieType][2]);
+			IceAndFire.PROXY.spawnParticle("if_pixie", this.pos.getX() + 0.5F + (double) (this.rand.nextFloat() * PARTICLE_WIDTH * 2F) - (double) PARTICLE_WIDTH, this.pos.getY() + (double) (this.rand.nextFloat() * PARTICLE_HEIGHT), this.pos.getZ() + 0.5F + (double) (this.rand.nextFloat() * PARTICLE_WIDTH * 2F) - (double) PARTICLE_WIDTH, EntityPixie.PARTICLE_RGB[this.pixieType][0], EntityPixie.PARTICLE_RGB[this.pixieType][1], EntityPixie.PARTICLE_RGB[this.pixieType][2]);
 		}
 	}
 

--- a/src/main/java/com/github/alexthe666/iceandfire/event/EventClient.java
+++ b/src/main/java/com/github/alexthe666/iceandfire/event/EventClient.java
@@ -162,7 +162,7 @@ public class EventClient {
 				}
 				if (sirenProps.isCharmed) {
 					if (rand.nextInt(40) == 0) {
-						IceAndFire.PROXY.spawnParticle("siren_appearance", player.world, player.posX, player.posY, player.posZ, 0, 0, 0);
+						IceAndFire.PROXY.spawnParticle("siren_appearance", player.posX, player.posY, player.posZ, 0, 0, 0);
 					}
 
 					if (IceAndFire.CONFIG.sirenShader && sirenProps.isCharmed && !renderer.isShaderActive()) {


### PR DESCRIPTION
Usage of the proxy classes to spawn particles currently allows the server's world to be easily leaked into the client side. It is not valid to use any server objects on a side other than the server.

This patch removes the World argument from the methods relevant to spawning particles in Ice and Fire's proxies and instead grabs it from `Minecraft#getInstance()`.

Fixes #1558, fixes #1500, fixes #1543, fixes #1530, fixes #1565, and fixes #1555.