### PR TITLE
Add whitelist option for breakable blocks.

### DIFF
--- a/src/main/java/com/github/alexthe666/iceandfire/IceAndFireConfig.java
+++ b/src/main/java/com/github/alexthe666/iceandfire/IceAndFireConfig.java
@@ -26,6 +26,7 @@ public class IceAndFireConfig {
     public int[] structureBlacklistedDimensions = new int[]{1, -1};
     public int[] structureWhitelistedDimensions = new int[]{0};
     public String[] blacklistedBreakBlocks = new String[0];
+    public boolean blacklistBreakBlocksIsWhiteList = false;
     public boolean spawnGlaciers = true;
     public int glacierSpawnChance = 4;
     public int oreToStoneRatioForDragonCaves = 45;
@@ -181,6 +182,7 @@ public class IceAndFireConfig {
         this.villagersFearDragons = config.getBoolean("Villagers Fear Dragons", "all", true, "True if villagers should run away and hide from dragons and other hostile Ice and Fire mobs.");
         this.animalsFearDragons = config.getBoolean("Animals Fear Dragons", "all", true, "True if animals should run away and hide from dragons and other hostile Ice and Fire mobs.");
         this.blacklistedBreakBlocks = config.getStringList("Blacklisted Blocks from Dragon", "all", new String[0], "Blacklist for blocks that dragons are not to break or burn. Ex. \"minecraft:chest\" or \"rats:rat_crafting_table\"");
+        this.blacklistBreakBlocksIsWhiteList = config.getBoolean("Blacklisted Blocks from Dragon is a Whitelist", "all", false, "If true, then the blacklist will act as a whitelist.");
 
 
         this.spawnHippogryphs = config.getBoolean("Spawn Hippogryphs", "all", true, "True if hippogryphs are allowed to spawn");

--- a/src/main/java/com/github/alexthe666/iceandfire/entity/DragonUtils.java
+++ b/src/main/java/com/github/alexthe666/iceandfire/entity/DragonUtils.java
@@ -304,12 +304,22 @@ public class DragonUtils {
     }
 
     public static boolean isBlacklistedBlock(Block block) {
-        for (String name : IceAndFire.CONFIG.blacklistedBreakBlocks) {
-            if (name.equalsIgnoreCase(block.getRegistryName().toString())) {
-                return true;
+        if(IceAndFire.CONFIG.blacklistBreakBlocksIsWhiteList) {
+            for (String name: IceAndFire.CONFIG.blacklistedBreakBlocks) {
+                if (name.equalsIgnoreCase(block.getRegistryName().toString())) {
+                    return false;
+                }
             }
+            return true;
         }
-        return false;
+        else {
+            for (String name : IceAndFire.CONFIG.blacklistedBreakBlocks) {
+                if (name.equalsIgnoreCase(block.getRegistryName().toString())) {
+                    return true;
+                }
+            }
+            return false;
+        }
     }
 
     public static boolean canHostilesTarget(Entity entity) {


### PR DESCRIPTION
This doesn't prevent charring/burning, but it does prevent dragons from breaking blocks with their bodies. I did this so that I didn't have to write out hundreds of unbreakable blocks into my config file.

I've tested it in game and it seems to work.