### PR TITLE
Teal Sea Serpents don't spawn.

### DIFF
--- a/src/main/java/com/github/alexthe666/iceandfire/entity/EntitySeaSerpent.java
+++ b/src/main/java/com/github/alexthe666/iceandfire/entity/EntitySeaSerpent.java
@@ -726,7 +726,7 @@ public class EntitySeaSerpent extends EntityAnimal implements IAnimatedEntity, I
     }
 
     public void onWorldSpawn(Random random) {
-        this.setVariant(random.nextInt(6));
+        this.setVariant(random.nextInt(7));
         boolean ancient = random.nextInt(15) == 1;
         if (ancient) {
             this.setAncient(true);


### PR DESCRIPTION
Teal variation is Case 6, of cases 0 - 6.
random.nextInt(int) is determined as random.nextInt((max-min)+1)+min.
((6-0)+1)+0 = 7

Currently, random.nextInt(6) is used, and will only output 0-5.

As it is, Teal serpents can not spawn due to this. I do not know if this needs to be updated anywhere else in the code for Teal to be allowed.

The public cries out for Teal serpents, "Where is the teal?" Alas, they are limited to only 2 variations of blue.