### PR TITLE
Fix #2920 remove registration of NULL owner ID

### DIFF
--- a/src/main/java/com/github/alexthe666/iceandfire/entity/EntityDragonEgg.java
+++ b/src/main/java/com/github/alexthe666/iceandfire/entity/EntityDragonEgg.java
@@ -83,7 +83,6 @@ public class EntityDragonEgg extends LivingEntity implements IBlacklistedFromSta
         super.registerData();
         this.getDataManager().register(DRAGON_TYPE, Integer.valueOf(0));
         this.getDataManager().register(DRAGON_AGE, Integer.valueOf(0));
-        this.dataManager.register(OWNER_UNIQUE_ID, null);
     }
 
     @Nullable


### PR DESCRIPTION
Dragon breeding issues still persist in 2.0.3.  Removing this line which attempts to register a NULL owner ID for DragonEgg entities appears to solve the issue.