### PR TITLE
Fix for tamed Pixies not keeping their sitting state upon rejoining world

### DIFF
--- a/src/main/java/com/github/alexthe666/iceandfire/client/model/ModelPixie.java
+++ b/src/main/java/com/github/alexthe666/iceandfire/client/model/ModelPixie.java
@@ -139,7 +139,7 @@ public class ModelPixie extends ModelDragonBase<EntityPixie> {
             this.Left_Arm.rotateAngleX = MathHelper.cos(f * 0.6662F) * 1.0F * f1 * 0.5F / 1;
         }
 
-        if (entity.func_233684_eK_()) {
+        if (entity.isSitting()) {
             this.Right_Arm.rotateAngleX += -((float) Math.PI / 5F);
             this.Left_Arm.rotateAngleX += -((float) Math.PI / 5F);
             this.Right_Leg.rotateAngleX = -1.4137167F;


### PR DESCRIPTION
Borrowed code from Hippogryph to implement sitting state using a COMMAND data manager variabable that gets checked in livingTick(). Accessor methods for sitting state implemented. Inherited func_233684_eK_(), which is the obfuscated name for isSitting() most probably, overridden and base class' member variable for isSitting set accordingly. And made Pixie's immune to damage from their owners. 