### PR TITLE
Fix ItemRottenEgg.onRightClick() resulting in throwing straight up.

### DIFF
--- a/src/main/java/com/github/alexthe666/iceandfire/item/ItemRottenEgg.java
+++ b/src/main/java/com/github/alexthe666/iceandfire/item/ItemRottenEgg.java
@@ -32,7 +32,7 @@ public class ItemRottenEgg extends Item {
 
         if (!worldIn.isRemote) {
             EntityCockatriceEgg entityegg = new EntityCockatriceEgg(IafEntityRegistry.COCKATRICE_EGG, worldIn, playerIn);
-            entityegg.shoot(playerIn.rotationPitch, playerIn.rotationYaw, 0.0F, 1.5F, 1.0F);
+            entityegg.func_234612_a_(playerIn, playerIn.rotationPitch, playerIn.rotationYaw, 0.0F, 1.5F, 1.0F);
             worldIn.addEntity(entityegg);
         }
 


### PR DESCRIPTION
Using inherited method **func_234612_a()** instead of **shoot()** in EntityCockatriceEgg.