### PR TITLE
Dragonforge Fixes

### DIFF
--- a/src/main/java/com/github/alexthe666/iceandfire/entity/tile/TileEntityDragonforge.java
+++ b/src/main/java/com/github/alexthe666/iceandfire/entity/tile/TileEntityDragonforge.java
@@ -295,11 +295,11 @@ public class TileEntityDragonforge extends TileEntity implements ITickable, ISid
         if (index == 2) {
             return false;
         } else if (index == 1) {
-            DragonForgeRecipe forgeRecipe = null;
+            DragonForgeRecipe forgeRecipe;
             if (this.isFire) {
-                forgeRecipe = IafRecipeRegistry.getFireForgeRecipeForBlood(this.forgeItemStacks.get(0));
+                forgeRecipe = IafRecipeRegistry.getFireForgeRecipeForBlood(stack);
             } else {
-                forgeRecipe = IafRecipeRegistry.getIceForgeRecipeForBlood(this.forgeItemStacks.get(0));
+                forgeRecipe = IafRecipeRegistry.getIceForgeRecipeForBlood(stack);
             }
             if (forgeRecipe != null) {
                 return true;

--- a/src/main/java/com/github/alexthe666/iceandfire/entity/tile/TileEntityDragonforge.java
+++ b/src/main/java/com/github/alexthe666/iceandfire/entity/tile/TileEntityDragonforge.java
@@ -189,49 +189,71 @@ public class TileEntityDragonforge extends TileEntity implements ITickable, ISid
         return 1000;
     }
 
-    private ItemStack getCurrentResult() {
-        DragonForgeRecipe forgeRecipe = null;
+    private DragonForgeRecipe getCurrentRecipe() {
+        ItemStack inputItemStack = this.forgeItemStacks.get(0);
+        ItemStack bloodItemStack = this.forgeItemStacks.get(1);
+
+        DragonForgeRecipe forgeRecipe;
         if (this.isFire) {
-            forgeRecipe = IafRecipeRegistry.getFireForgeRecipe(this.forgeItemStacks.get(0));
+            forgeRecipe = IafRecipeRegistry.getFireForgeRecipe(inputItemStack);
         } else {
-            forgeRecipe = IafRecipeRegistry.getIceForgeRecipe(this.forgeItemStacks.get(0));
+            forgeRecipe = IafRecipeRegistry.getIceForgeRecipe(inputItemStack);
         }
-        ItemStack itemstack = ItemStack.EMPTY;
-        if (forgeRecipe != null && this.forgeItemStacks.get(1).isItemEqual(forgeRecipe.getBlood())) {
-            itemstack = forgeRecipe.getOutput();
+
+        if (
+            forgeRecipe != null &&
+            // Input item and quantity match
+            inputItemStack.isItemEqual(forgeRecipe.getInput()) &&
+            inputItemStack.getCount() >= forgeRecipe.getInput().getCount() &&
+            // Blood item and quantity match
+            bloodItemStack.isItemEqual(forgeRecipe.getBlood()) &&
+            bloodItemStack.getCount() >= forgeRecipe.getBlood().getCount()
+        ) {
+            return forgeRecipe;
         }
-        if (itemstack == ItemStack.EMPTY) {
-            if (this.isFire) {
-                itemstack = new ItemStack(IafBlockRegistry.ash);
-            } else {
-                itemstack = new ItemStack(IafBlockRegistry.dragon_ice);
-            }
+
+        Block defaultOutput = IafBlockRegistry.dragon_ice;
+        if (this.isFire) {
+            defaultOutput = IafBlockRegistry.ash;
         }
-        return itemstack;
+
+        return new DragonForgeRecipe(
+            new ItemStack(inputItemStack.getItem()),
+            new ItemStack(bloodItemStack.getItem()),
+            new ItemStack(defaultOutput)
+        );
+    }
+
+    private ItemStack getCurrentResult() {
+        return getCurrentRecipe().getOutput();
     }
 
     public boolean canSmelt() {
-        if (this.forgeItemStacks.get(0).isEmpty()) {
+        ItemStack inputItemStack = this.forgeItemStacks.get(0);
+        if (inputItemStack.isEmpty()) {
             return false;
-        } else {
-            ItemStack itemstack = getCurrentResult();
-            if (itemstack.isEmpty()) {
-                return false;
-            } else {
-                ItemStack itemstack1 = this.forgeItemStacks.get(2);
-
-                if (itemstack1.isEmpty()) {
-                    return true;
-                } else if (!itemstack1.isItemEqual(itemstack)) {
-                    return false;
-                } else if (itemstack1.getCount() + itemstack.getCount() <= this.getInventoryStackLimit() && itemstack1.getCount() + itemstack.getCount() <= itemstack1.getMaxStackSize())  // Forge fix: make furnace respect stack sizes in furnace recipes
-                {
-                    return true;
-                } else {
-                    return itemstack1.getCount() + itemstack.getCount() <= itemstack.getMaxStackSize(); // Forge fix: make furnace respect stack sizes in furnace recipes
-                }
-            }
         }
+
+        DragonForgeRecipe forgeRecipe = getCurrentRecipe();
+        ItemStack forgeRecipeOutput = forgeRecipe.getOutput();
+
+        if (forgeRecipeOutput.isEmpty()) {
+            return false;
+        }
+
+        ItemStack outputItemStack = this.forgeItemStacks.get(2);
+        if (
+            !outputItemStack.isEmpty() &&
+            !outputItemStack.isItemEqual(forgeRecipeOutput)
+        ) {
+            return false;
+        }
+
+        int calculatedOutputCount = outputItemStack.getCount() + forgeRecipeOutput.getCount();
+        return (
+             calculatedOutputCount <= this.getInventoryStackLimit() &&
+             calculatedOutputCount <= outputItemStack.getMaxStackSize()
+        );
     }
 
     public boolean isUsableByPlayer(EntityPlayer player) {
@@ -243,22 +265,24 @@ public class TileEntityDragonforge extends TileEntity implements ITickable, ISid
     }
 
     public void smeltItem() {
-        if (this.canSmelt()) {
-            ItemStack itemstack = this.forgeItemStacks.get(0);
-            ItemStack bloodStack = this.forgeItemStacks.get(1);
-            ItemStack itemstack1 = getCurrentResult();
-            ItemStack itemstack2 = this.forgeItemStacks.get(2);
-
-            if (itemstack2.isEmpty()) {
-                this.forgeItemStacks.set(2, itemstack1.copy());
-            } else if (itemstack2.getItem() == itemstack1.getItem()) {
-                itemstack2.grow(itemstack1.getCount());
-            }
-            if (!bloodStack.isEmpty() && this.cookTime == 0) {
-                bloodStack.shrink(1);
-            }
-            itemstack.shrink(1);
+        if (!this.canSmelt()) {
+            return;
         }
+
+        DragonForgeRecipe forgeRecipe = getCurrentRecipe();
+
+        ItemStack inputItemStack = this.forgeItemStacks.get(0);
+        ItemStack bloodItemStack = this.forgeItemStacks.get(1);
+        ItemStack outputItemStack = this.forgeItemStacks.get(2);
+
+        if (outputItemStack.isEmpty()) {
+            this.forgeItemStacks.set(2, forgeRecipe.getOutput().copy());
+        } else {
+            outputItemStack.grow(forgeRecipe.getOutput().getCount());
+        }
+
+        inputItemStack.shrink(forgeRecipe.getInput().getCount());
+        bloodItemStack.shrink(forgeRecipe.getBlood().getCount());
     }
 
     public void openInventory(EntityPlayer player) {

--- a/src/main/java/com/github/alexthe666/iceandfire/entity/tile/TileEntityDragonforgeInput.java
+++ b/src/main/java/com/github/alexthe666/iceandfire/entity/tile/TileEntityDragonforgeInput.java
@@ -47,7 +47,7 @@ public class TileEntityDragonforgeInput extends TileEntity implements ITickable 
     }
 
     protected void lureDragons() {
-        if (core != null && core.canSmelt()) {
+        if (core != null && core.assembled() && core.canSmelt()) {
             for (EntityDragonBase dragon : world.getEntitiesWithinAABB(EntityDragonBase.class, new AxisAlignedBB((double) pos.getX() - LURE_DISTANCE, (double) pos.getY() - LURE_DISTANCE, (double) pos.getZ() - LURE_DISTANCE, (double) pos.getX() + LURE_DISTANCE, (double) pos.getY() + LURE_DISTANCE, (double) pos.getZ() + LURE_DISTANCE))) {
                 if (isFire() == (dragon.dragonType == DragonType.FIRE) && (dragon.isChained() || dragon.isTamed()) && canSeeInput(dragon, new Vec3d(this.getPos().getX() + 0.5F, this.getPos().getY() + 0.5F, this.getPos().getZ() + 0.5F))) {
                     dragon.burningTarget = this.pos;


### PR DESCRIPTION
Applies the following fixes to the dragonforge:

1. Support Craft Tweaker recipes that consume multiple inputs (#3291)
2. Correct validity checks for blood slot automated insertion (#2421)
3. Ensure forges are assembled before luring dragons

I primarily applied the Craft Tweaker patch for a private 1.12 server but these changes could totally be ported to the 1.16 version as well since the issues still appear to be present.