### PR TITLE
Various (hot)-fixes + dragon pathfinding

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,2 @@
+# Ice_and_Fire
+Integrating async flying to help prevent various TPS issues.

--- a/README.md
+++ b/README.md
@@ -1,2 +1,6 @@
 # Ice_and_Fire
-Integrating async flying to help prevent various TPS issues.
+This fork fixes the following:
+  1. Hotfix for mausoleum generation being able to freeze the game indefinitely
+  2. Hotfix for reimplementing dangerous gen
+  3. Hotfix for lectern not using up manuscript pages
+  4. Integrated async flying to help prevent various TPS issues related to dragons

--- a/src/main/java/com/github/alexthe666/iceandfire/entity/EntityDragonBase.java
+++ b/src/main/java/com/github/alexthe666/iceandfire/entity/EntityDragonBase.java
@@ -473,8 +473,8 @@ public abstract class EntityDragonBase extends TameableEntity implements IPassab
 
     protected abstract void breathFireAtPos(BlockPos burningTarget);
 
-    protected PathNavigator createNavigator(World worldIn) {
-        DragonAdvancedPathNavigate newNavigator = new DragonAdvancedPathNavigate(this, world);
+    protected PathNavigator createNavigator(World worldIn, boolean canFly) {
+        DragonAdvancedPathNavigate newNavigator = new DragonAdvancedPathNavigate(this, world,canFly);
         this.navigator = newNavigator;
         newNavigator.setCanSwim(true);
         newNavigator.getNodeProcessor().setCanOpenDoors(true);
@@ -484,17 +484,17 @@ public abstract class EntityDragonBase extends TameableEntity implements IPassab
     protected void switchNavigator(int navigatorType) {
         if (navigatorType == 0) {
             this.moveController = new IafDragonFlightManager.GroundMoveHelper(this);
-            this.navigator = createNavigator(world);
+            this.navigator = createNavigator(world,false);
             this.navigatorType = 0;
             this.setFlying(false);
             this.setHovering(false);
         } else if (navigatorType == 1) {
             this.moveController = new IafDragonFlightManager.FlightMoveHelper(this);
-            this.navigator = new PathNavigateFlyingCreature(this, world);
+            this.navigator = createNavigator(world,true);
             this.navigatorType = 1;
         } else {
             this.moveController = new IafDragonFlightManager.PlayerFlightMoveHelper(this);
-            this.navigator = new PathNavigateFlyingCreature(this, world);
+            this.navigator = createNavigator(world,true);
             this.navigatorType = 2;
         }
     }

--- a/src/main/java/com/github/alexthe666/iceandfire/entity/EntityMyrmexBase.java
+++ b/src/main/java/com/github/alexthe666/iceandfire/entity/EntityMyrmexBase.java
@@ -203,8 +203,8 @@ public abstract class EntityMyrmexBase extends AnimalEntity implements IAnimated
         return this.world.getBlockState(pos.down()).getBlock() instanceof BlockMyrmexResin ? 10.0F : super.getBlockPathWeight(pos);
     }
 
-    protected PathNavigator createNavigator(World worldIn) {
-        DragonAdvancedPathNavigate newNavigator = new DragonAdvancedPathNavigate(this, world);
+    protected PathNavigator createNavigator(World worldIn,boolean canfly) {
+        DragonAdvancedPathNavigate newNavigator = new DragonAdvancedPathNavigate(this, world,canfly);
         this.navigator = newNavigator;
         newNavigator.setCanSwim(true);
         newNavigator.getNodeProcessor().setCanOpenDoors(true);

--- a/src/main/java/com/github/alexthe666/iceandfire/entity/EntityMyrmexBase.java
+++ b/src/main/java/com/github/alexthe666/iceandfire/entity/EntityMyrmexBase.java
@@ -203,8 +203,8 @@ public abstract class EntityMyrmexBase extends AnimalEntity implements IAnimated
         return this.world.getBlockState(pos.down()).getBlock() instanceof BlockMyrmexResin ? 10.0F : super.getBlockPathWeight(pos);
     }
 
-    protected PathNavigator createNavigator(World worldIn,boolean canfly) {
-        DragonAdvancedPathNavigate newNavigator = new DragonAdvancedPathNavigate(this, world,canfly);
+    protected PathNavigator createNavigator(World worldIn,boolean isFlying) {
+        DragonAdvancedPathNavigate newNavigator = new DragonAdvancedPathNavigate(this, world,isFlying);
         this.navigator = newNavigator;
         newNavigator.setCanSwim(true);
         newNavigator.getNodeProcessor().setCanOpenDoors(true);

--- a/src/main/java/com/github/alexthe666/iceandfire/entity/EntityMyrmexRoyal.java
+++ b/src/main/java/com/github/alexthe666/iceandfire/entity/EntityMyrmexRoyal.java
@@ -113,11 +113,11 @@ public class EntityMyrmexRoyal extends EntityMyrmexBase {
     protected void switchNavigator(boolean onLand) {
         if (onLand) {
             this.moveController = new MovementController(this);
-            this.navigator = createNavigator(world);
+            this.navigator = createNavigator(world,false);
             this.isLandNavigator = true;
         } else {
             this.moveController = new EntityMyrmexRoyal.FlyMoveHelper(this);
-            this.navigator = createNavigator(world);
+            this.navigator = createNavigator(world,true);
             this.isLandNavigator = false;
         }
     }

--- a/src/main/java/com/github/alexthe666/iceandfire/inventory/ContainerLectern.java
+++ b/src/main/java/com/github/alexthe666/iceandfire/inventory/ContainerLectern.java
@@ -163,7 +163,7 @@ public class ContainerLectern extends Container {
                         ((TileEntityLectern) IceAndFire.PROXY.getRefrencedTE()).randomizePages(itemstack, itemstack1);
                     }
                 }
-                if (!playerIn.isCreative() && didEnchant) {
+                if (!playerIn.isCreative()) {
                     itemstack1.shrink(i);
                     if (itemstack1.isEmpty()) {
                         this.tileFurnace.setInventorySlotContents(1, ItemStack.EMPTY);

--- a/src/main/java/com/github/alexthe666/iceandfire/pathfinding/NodeProcessorDragonFly.java
+++ b/src/main/java/com/github/alexthe666/iceandfire/pathfinding/NodeProcessorDragonFly.java
@@ -1,0 +1,21 @@
+package com.github.alexthe666.iceandfire.pathfinding;
+
+import net.minecraft.entity.MobEntity;
+import net.minecraft.pathfinding.FlyingNodeProcessor;
+import net.minecraft.pathfinding.WalkNodeProcessor;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.util.math.MathHelper;
+import net.minecraft.world.Region;
+
+public class NodeProcessorDragonFly extends FlyingNodeProcessor {
+
+    public void func_225578_a_(Region p_225578_1_, MobEntity p_225578_2_) {
+        super.func_225578_a_(p_225578_1_, p_225578_2_);
+    }
+
+    public void setEntitySize(float width, float height){
+        this.entitySizeX = MathHelper.floor(width + 1.0F);
+        this.entitySizeY = MathHelper.floor(height + 1.0F);
+        this.entitySizeZ = MathHelper.floor(width + 1.0F);
+    }
+}

--- a/src/main/java/com/github/alexthe666/iceandfire/pathfinding/NodeProcessorDragonWalk.java
+++ b/src/main/java/com/github/alexthe666/iceandfire/pathfinding/NodeProcessorDragonWalk.java
@@ -1,11 +1,12 @@
 package com.github.alexthe666.iceandfire.pathfinding;
 
 import net.minecraft.entity.MobEntity;
+import net.minecraft.pathfinding.FlyingNodeProcessor;
 import net.minecraft.pathfinding.WalkNodeProcessor;
 import net.minecraft.util.math.MathHelper;
 import net.minecraft.world.Region;
 
-public class NodeProcessorDragon extends WalkNodeProcessor {
+public class NodeProcessorDragonWalk extends WalkNodeProcessor {
 
     public void func_225578_a_(Region p_225578_1_, MobEntity p_225578_2_) {
         super.func_225578_a_(p_225578_1_, p_225578_2_);

--- a/src/main/java/com/github/alexthe666/iceandfire/pathfinding/raycoms/DragonAdvancedPathNavigate.java
+++ b/src/main/java/com/github/alexthe666/iceandfire/pathfinding/raycoms/DragonAdvancedPathNavigate.java
@@ -3,7 +3,8 @@ package com.github.alexthe666.iceandfire.pathfinding.raycoms;
     All of this code is used with permission from Raycoms, one of the developers of the minecolonies project.
  */
 import com.github.alexthe666.iceandfire.IceAndFire;
-import com.github.alexthe666.iceandfire.pathfinding.NodeProcessorDragon;
+import com.github.alexthe666.iceandfire.pathfinding.NodeProcessorDragonFly;
+import com.github.alexthe666.iceandfire.pathfinding.NodeProcessorDragonWalk;
 import com.github.alexthe666.iceandfire.pathfinding.raycoms.pathjobs.*;
 
 import net.minecraft.entity.Entity;
@@ -66,22 +67,29 @@ public class DragonAdvancedPathNavigate extends AbstractAdvancedPathNavigate {
      */
     private boolean isSneaking = true;
 
+    private boolean canFly = false;
     /**
      * Instantiates the navigation of an ourEntity.
      *
      * @param entity the ourEntity.
      * @param world  the world it is in.
      */
-    public DragonAdvancedPathNavigate(final MobEntity entity, final World world) {
+    public DragonAdvancedPathNavigate(final MobEntity entity, final World world, final boolean canFly) {
         super(entity, world);
-
-        this.nodeProcessor = new NodeProcessorDragon();
+        if(canFly) {
+            this.nodeProcessor = new NodeProcessorDragonFly();
+            getPathingOptions().setCanFly(true);
+        }
+        else{
+            this.nodeProcessor = new NodeProcessorDragonWalk();
+        }
         this.nodeProcessor.setCanEnterDoors(true);
         getPathingOptions().setEnterDoors(true);
         this.nodeProcessor.setCanOpenDoors(true);
         getPathingOptions().setCanOpenDoors(true);
         this.nodeProcessor.setCanSwim(true);
         getPathingOptions().setCanSwim(true);
+
 
         stuckHandler = PathingStuckHandler.createStuckHandler().withTakeDamageOnStuck(0.2f).withTeleportSteps(6).withTeleportOnFullStuck();
     }
@@ -160,7 +168,12 @@ public class DragonAdvancedPathNavigate extends AbstractAdvancedPathNavigate {
 
     @Override
     public void tick() {
-        ((NodeProcessorDragon)nodeProcessor).setEntitySize(4, 4);
+        if (nodeProcessor instanceof  NodeProcessorDragonWalk){
+            ((NodeProcessorDragonWalk)nodeProcessor).setEntitySize(4, 4);
+        }
+        else{
+            ((NodeProcessorDragonFly)nodeProcessor).setEntitySize(4, 4);
+        }
         if (desiredPosTimeout > 0) {
             if (desiredPosTimeout-- <= 0) {
                 desiredPos = null;

--- a/src/main/java/com/github/alexthe666/iceandfire/pathfinding/raycoms/DragonAdvancedPathNavigate.java
+++ b/src/main/java/com/github/alexthe666/iceandfire/pathfinding/raycoms/DragonAdvancedPathNavigate.java
@@ -74,11 +74,11 @@ public class DragonAdvancedPathNavigate extends AbstractAdvancedPathNavigate {
      * @param entity the ourEntity.
      * @param world  the world it is in.
      */
-    public DragonAdvancedPathNavigate(final MobEntity entity, final World world, final boolean canFly) {
+    public DragonAdvancedPathNavigate(final MobEntity entity, final World world, final boolean isFlying) {
         super(entity, world);
-        if(canFly) {
+        if(isFlying) {
             this.nodeProcessor = new NodeProcessorDragonFly();
-            getPathingOptions().setCanFly(true);
+            getPathingOptions().setIsFlying(true);
         }
         else{
             this.nodeProcessor = new NodeProcessorDragonWalk();

--- a/src/main/java/com/github/alexthe666/iceandfire/pathfinding/raycoms/PathingOptions.java
+++ b/src/main/java/com/github/alexthe666/iceandfire/pathfinding/raycoms/PathingOptions.java
@@ -50,6 +50,8 @@ public class PathingOptions {
      */
     private boolean canOpenDoors = false;
 
+    private boolean canFly = false;
+
     public PathingOptions() {
     }
 
@@ -84,6 +86,10 @@ public class PathingOptions {
     public void setEnterDoors(final boolean enterDoors) {
         this.enterDoors = enterDoors;
     }
+
+    public boolean canFly(){return this.canFly;}
+
+    public void setCanFly(final boolean canFly){this.canFly = canFly;}
 
     public PathingOptions withStartSwimCost(final double startSwimCost) {
         swimCostEnter = startSwimCost;

--- a/src/main/java/com/github/alexthe666/iceandfire/pathfinding/raycoms/PathingOptions.java
+++ b/src/main/java/com/github/alexthe666/iceandfire/pathfinding/raycoms/PathingOptions.java
@@ -50,7 +50,7 @@ public class PathingOptions {
      */
     private boolean canOpenDoors = false;
 
-    private boolean canFly = false;
+    private boolean flying = false;
 
     public PathingOptions() {
     }
@@ -87,9 +87,9 @@ public class PathingOptions {
         this.enterDoors = enterDoors;
     }
 
-    public boolean canFly(){return this.canFly;}
+    public boolean isFlying(){return this.flying;}
 
-    public void setCanFly(final boolean canFly){this.canFly = canFly;}
+    public void setIsFlying(final boolean flying){this.flying = flying;}
 
     public PathingOptions withStartSwimCost(final double startSwimCost) {
         swimCostEnter = startSwimCost;

--- a/src/main/java/com/github/alexthe666/iceandfire/pathfinding/raycoms/pathjobs/AbstractPathJob.java
+++ b/src/main/java/com/github/alexthe666/iceandfire/pathfinding/raycoms/pathjobs/AbstractPathJob.java
@@ -22,7 +22,6 @@ import net.minecraft.util.math.MathHelper;
 import net.minecraft.util.math.shapes.VoxelShape;
 import net.minecraft.world.IWorldReader;
 import net.minecraft.world.World;
-import sun.java2d.Surface;
 
 import javax.annotation.Nullable;
 import java.lang.ref.WeakReference;
@@ -43,6 +42,7 @@ public abstract class AbstractPathJob implements Callable<Path> {
     public static Set<Node> lastDebugNodesPath;
 
     protected final BlockPos start;
+    protected final BlockPos end;
 
     protected final IWorldReader world;
     protected final PathResult result;
@@ -63,6 +63,7 @@ public abstract class AbstractPathJob implements Callable<Path> {
     protected WeakReference<LivingEntity> entity;
     //  May be faster, but can produce strange results
     private boolean allowJumpPointSearchTypeWalk;
+    private boolean allowJumpPointSearchTypeFly;
     private int totalNodesAdded = 0;
     private int totalNodesVisited = 0;
     private float entitySizeXZ = 1;
@@ -125,12 +126,13 @@ public abstract class AbstractPathJob implements Callable<Path> {
         this.world = new ChunkCache(world, new BlockPos(minX, MIN_Y, minZ), new BlockPos(maxX, MAX_Y, maxZ), range);
 
         this.start = new BlockPos(start);
+        this.end = new BlockPos(end);
         this.maxRange = range;
 
         this.result = result;
 
         allowJumpPointSearchTypeWalk = false;
-
+        allowJumpPointSearchTypeFly = false;
         if (Pathfinding.isDebug()) {
             debugDrawEnabled = true;
             debugNodesVisited = new HashSet<>();
@@ -164,12 +166,13 @@ public abstract class AbstractPathJob implements Callable<Path> {
         this.world = new ChunkCache(world, new BlockPos(minX, MIN_Y, minZ), new BlockPos(maxX, MAX_Y, maxZ), range);
 
         this.start = startRestriction;
+        this.end = new BlockPos(endRestriction);
         this.maxRange = range;
 
         this.result = result;
 
         allowJumpPointSearchTypeWalk = false;
-
+        allowJumpPointSearchTypeFly = false;
         if (Pathfinding.isDebug()) {
             debugDrawEnabled = true;
             debugNodesVisited = new HashSet<>();
@@ -318,6 +321,7 @@ public abstract class AbstractPathJob implements Callable<Path> {
         entitySizeXZ = entity.getWidth() / 2.0F;
         entitySizeY = MathHelper.ceil(entity.getHeight());
         allowJumpPointSearchTypeWalk = true;
+        allowJumpPointSearchTypeFly = true;
     }
 
     /**
@@ -435,12 +439,8 @@ public abstract class AbstractPathJob implements Callable<Path> {
             }
 
             if (!xzRestricted || (currentNode.pos.getX() >= minX && currentNode.pos.getX() <= maxX && currentNode.pos.getZ() >= minZ && currentNode.pos.getZ() <= maxZ)) {
-                if(pathingOptions.canFly()) {
-                    flyCurrentNode(currentNode);
-                }
-                else{
-                    walkCurrentNode(currentNode);
-                }
+                walkCurrentNode(currentNode);
+
             }
         }
 
@@ -519,50 +519,6 @@ public abstract class AbstractPathJob implements Callable<Path> {
             walk(currentNode, BLOCKPOS_WEST);
         }
     }
-    //TODO: Adjust possible nodes
-    //Since I'm not too familiar with which way a flying dragon should be able to take this might not be the most
-    //optimal/best way,
-    private void flyCurrentNode(final Node currentNode){
-        BlockPos dPos = BLOCKPOS_IDENTITY;
-        if (currentNode.parent != null) {
-            dPos = currentNode.pos.subtract(currentNode.parent.pos);
-        }
-        if (dPos.getY() >= 0) {
-            fly(currentNode, BLOCKPOS_UP);
-        }
-        if (dPos.getY() <= 0) {
-            fly(currentNode, BLOCKPOS_DOWN);
-        }
-        /*if (currentNode.parent != null && isPassableBBDown(currentNode.parent.pos, currentNode.pos.down())) {
-            fly(currentNode, BLOCKPOS_DOWN);
-        }*/
-
-
-        // Walk downwards node if passable
-        /*if (currentNode.parent != null && isPassableBBDown(currentNode.parent.pos, currentNode.pos.down())) {
-            fly(currentNode, BLOCKPOS_DOWN);
-        }*/
-
-        // N
-        if (dPos.getZ() <= 0) {
-            fly(currentNode, BLOCKPOS_NORTH);
-        }
-
-        // E
-        if (dPos.getX() >= 0) {
-            fly(currentNode, BLOCKPOS_EAST);
-        }
-
-        // S
-        if (dPos.getZ() >= 0) {
-            fly(currentNode, BLOCKPOS_SOUTH);
-        }
-
-        // W
-        if (dPos.getX() <= 0) {
-            fly(currentNode, BLOCKPOS_WEST);
-        }
-    }
     private boolean onLadderGoingDown(final Node currentNode, final BlockPos dPos) {
         return (dPos.getY() <= 0 || dPos.getX() != 0 || dPos.getZ() != 0) && isLadder(currentNode.pos.down());
     }
@@ -578,7 +534,11 @@ public abstract class AbstractPathJob implements Callable<Path> {
     }
 
     private Node getAndSetupStartNode() {
-        final Node startNode = new Node(start, computeHeuristic(start));
+        Node startNode = new Node(start, computeHeuristic(start));
+        if (pathingOptions.isFlying()){
+            startNode = new Node(end, computeHeuristic(end));
+        }
+
 
         if (isLadder(start)) {
             startNode.setLadder();
@@ -797,91 +757,11 @@ public abstract class AbstractPathJob implements Callable<Path> {
 
         return true;
     }
-    /**
-     * "Fly" from the parent in the direction specified by the delta, determining the new x,y,z position for such a move and adding or updating a node, as appropriate.
-     *
-     * @param parent Node being walked from.
-     * @param dPos   Delta from parent, expected in range of [-1..1].
-     * @return true if a node was added or updated when attempting to move in the given direction.
-     */
-    protected final boolean fly(final Node parent, BlockPos dPos) {
-        BlockPos pos = parent.pos.add(dPos);
-
-        //  Can we traverse into this node?  Fix the y up
-        final int newY = getGroundHeight(parent, pos);
-
-        if (newY < 0) {
-            return false;
-        }
-
-        boolean corner = false;
-        if (pos.getY() != newY) {
-            // if the new position is above the current node, we're taking the node directly above
-            if (!parent.isCornerNode() && newY - pos.getY() > 0 && (parent.parent == null || !parent.parent.pos.equals(parent.pos.add(new BlockPos(0, newY - pos.getY(), 0))))) {
-                dPos = new BlockPos(0, newY - pos.getY(), 0);
-                pos = parent.pos.add(dPos);
-                corner = true;
-            }
-            // If we're going down, take the air-corner before going to the lower node
-            else if (!parent.isCornerNode() && newY - pos.getY() < 0 && (dPos.getX() != 0 || dPos.getZ() != 0) && (parent.parent == null || !parent.pos.down()
-                    .equals(parent.parent.pos))) {
-                dPos = new BlockPos(dPos.getX(), 0, dPos.getZ());
-                pos = parent.pos.add(dPos);
-                corner = true;
-            }
-            // Fix up normal y
-            else {
-                dPos = dPos.add(0, newY - pos.getY(), 0);
-                pos = new BlockPos(pos.getX(), newY, pos.getZ());
-            }
-        }
-
-        int nodeKey = computeNodeKey(pos);
-        Node node = nodesVisited.get(nodeKey);
-        if (nodeClosed(node)) {
-            //  Early out on closed nodes (closed = expanded from)
-            return false;
-        }
-
-        final boolean isSwimming = calculateSwimming(world, pos, node);
-
-        if (isSwimming && !pathingOptions.canSwim()) {
-            return false;
-        }
-
-        final boolean swimStart = isSwimming && !parent.isSwimming();
-        final boolean onRoad = false;
-        final boolean onRails = pathingOptions.canUseRails() && world.getBlockState(pos).getBlock() instanceof AbstractRailBlock;
-        final boolean railsExit = !onRails && parent != null && parent.isOnRails();
-        //  Cost may have changed due to a jump up or drop
-        final double stepCost = computeCost(dPos, isSwimming, onRoad, onRails, railsExit, swimStart, pos);
-        final double heuristic = computeHeuristic(pos);
-        final double cost = parent.getCost() + stepCost;
-        final double score = cost + heuristic;
-
-        if (node == null) {
-            node = createNode(parent, pos, nodeKey, isSwimming, heuristic, cost, score);
-            node.setOnRails(onRails);
-            node.setCornerNode(corner);
-        } else if (updateCurrentNode(parent, node, heuristic, cost, score)) {
-            return false;
-        }
-
-        nodesOpen.offer(node);
-
-        //  Jump Point Search-ish optimization:
-        // If this node was a (heuristic-based) improvement on our parent,
-        // lets go another step in the same direction...
-        performJumpPointSearch(parent, dPos, node);
-
-        return true;
-    }
     private void performJumpPointSearch(final Node parent, final BlockPos dPos, final Node node) {
         if (allowJumpPointSearchTypeWalk && node.getHeuristic() <= parent.getHeuristic()) {
             walk(node, dPos);
         }
     }
-
     private Node createNode(
             final Node parent, final BlockPos pos, final int nodeKey,
             final boolean isSwimming, final double heuristic, final double cost, final double score) {
@@ -931,10 +811,11 @@ public abstract class AbstractPathJob implements Callable<Path> {
     protected int getGroundHeight(final Node parent, final BlockPos pos) {
         //  Check (y+1) first, as it's always needed, either for the upper body (level),
         //  lower body (headroom drop) or lower body (jump up)
-        if (checkHeadBlock(parent, pos)) {
-            return handleTargetNotPassable(parent, pos.up(), world.getBlockState(pos.up()));
+        if(!pathingOptions.isFlying()) {
+            if (checkHeadBlock(parent, pos)) {
+                return handleTargetNotPassable(parent, pos.up(), world.getBlockState(pos.up()));
+            }
         }
-
         //  Now check the block we want to move to
         final BlockState target = world.getBlockState(pos);
         if (parent != null && !isPassableBB(parent.pos, pos)) {
@@ -943,7 +824,7 @@ public abstract class AbstractPathJob implements Callable<Path> {
 
         //  Do we have something to stand on in the target space?
         final BlockState below = world.getBlockState(pos.down());
-        if(pathingOptions.canFly()){
+        if(pathingOptions.isFlying()){
              final SurfaceType flyability = isFlyable(below, pos);
              if (flyability == SurfaceType.FLYABLE){
                  return pos.getY();
@@ -951,7 +832,6 @@ public abstract class AbstractPathJob implements Callable<Path> {
              else if(flyability == SurfaceType.NOT_PASSABLE){
                  return -1;
              }
-            return handleNotStanding(parent, pos, below);
         }
         else{
             final SurfaceType walkability = isWalkableSurface(below, pos);
@@ -962,9 +842,12 @@ public abstract class AbstractPathJob implements Callable<Path> {
                 return -1;
             }
         }
-
-
-        return handleNotStanding(parent, pos, below);
+        if (!pathingOptions.isFlying()) {
+            return handleNotStanding(parent, pos, below);
+        }
+        else{
+            return pos.getY();
+        }
     }
 
     private int handleNotStanding(@Nullable final Node parent, final BlockPos pos, final BlockState below) {
@@ -1226,7 +1109,7 @@ public abstract class AbstractPathJob implements Callable<Path> {
         if (fluid != null && !fluid.isEmpty() && (fluid.getFluid() == Fluids.LAVA || fluid.getFluid() == Fluids.FLOWING_LAVA)) {
             return SurfaceType.NOT_PASSABLE;
         }
-        if (!blockState.getMaterial().isSolid()){
+        if (isPassable(blockState,pos)){
             return SurfaceType.FLYABLE;
         }
         return SurfaceType.DROPABLE;

--- a/src/main/java/com/github/alexthe666/iceandfire/pathfinding/raycoms/pathjobs/AbstractPathJob.java
+++ b/src/main/java/com/github/alexthe666/iceandfire/pathfinding/raycoms/pathjobs/AbstractPathJob.java
@@ -63,7 +63,6 @@ public abstract class AbstractPathJob implements Callable<Path> {
     protected WeakReference<LivingEntity> entity;
     //  May be faster, but can produce strange results
     private boolean allowJumpPointSearchTypeWalk;
-    private boolean allowJumpPointSearchTypeFly;
     private int totalNodesAdded = 0;
     private int totalNodesVisited = 0;
     private float entitySizeXZ = 1;
@@ -132,7 +131,6 @@ public abstract class AbstractPathJob implements Callable<Path> {
         this.result = result;
 
         allowJumpPointSearchTypeWalk = false;
-        allowJumpPointSearchTypeFly = false;
         if (Pathfinding.isDebug()) {
             debugDrawEnabled = true;
             debugNodesVisited = new HashSet<>();
@@ -172,7 +170,6 @@ public abstract class AbstractPathJob implements Callable<Path> {
         this.result = result;
 
         allowJumpPointSearchTypeWalk = false;
-        allowJumpPointSearchTypeFly = false;
         if (Pathfinding.isDebug()) {
             debugDrawEnabled = true;
             debugNodesVisited = new HashSet<>();
@@ -321,7 +318,6 @@ public abstract class AbstractPathJob implements Callable<Path> {
         entitySizeXZ = entity.getWidth() / 2.0F;
         entitySizeY = MathHelper.ceil(entity.getHeight());
         allowJumpPointSearchTypeWalk = true;
-        allowJumpPointSearchTypeFly = true;
     }
 
     /**

--- a/src/main/java/com/github/alexthe666/iceandfire/pathfinding/raycoms/pathjobs/AbstractPathJob.java
+++ b/src/main/java/com/github/alexthe666/iceandfire/pathfinding/raycoms/pathjobs/AbstractPathJob.java
@@ -811,11 +811,10 @@ public abstract class AbstractPathJob implements Callable<Path> {
     protected int getGroundHeight(final Node parent, final BlockPos pos) {
         //  Check (y+1) first, as it's always needed, either for the upper body (level),
         //  lower body (headroom drop) or lower body (jump up)
-        if(!pathingOptions.isFlying()) {
-            if (checkHeadBlock(parent, pos)) {
-                return handleTargetNotPassable(parent, pos.up(), world.getBlockState(pos.up()));
-            }
+        if (checkHeadBlock(parent, pos)) {
+            return handleTargetNotPassable(parent, pos.up(), world.getBlockState(pos.up()));
         }
+
         //  Now check the block we want to move to
         final BlockState target = world.getBlockState(pos);
         if (parent != null && !isPassableBB(parent.pos, pos)) {
@@ -842,12 +841,7 @@ public abstract class AbstractPathJob implements Callable<Path> {
                 return -1;
             }
         }
-        if (!pathingOptions.isFlying()) {
-            return handleNotStanding(parent, pos, below);
-        }
-        else{
-            return pos.getY();
-        }
+        return handleNotStanding(parent, pos, below);
     }
 
     private int handleNotStanding(@Nullable final Node parent, final BlockPos pos, final BlockState below) {

--- a/src/main/java/com/github/alexthe666/iceandfire/pathfinding/raycoms/pathjobs/AbstractPathJob.java
+++ b/src/main/java/com/github/alexthe666/iceandfire/pathfinding/raycoms/pathjobs/AbstractPathJob.java
@@ -521,7 +521,7 @@ public abstract class AbstractPathJob implements Callable<Path> {
     }
     //TODO: Adjust possible nodes
     //Since I'm not too familiar with which way a flying dragon should be able to take this might not be the most
-    //optimal way/best way,
+    //optimal/best way,
     private void flyCurrentNode(final Node currentNode){
         BlockPos dPos = BLOCKPOS_IDENTITY;
         if (currentNode.parent != null) {
@@ -530,9 +530,12 @@ public abstract class AbstractPathJob implements Callable<Path> {
         if (dPos.getY() >= 0) {
             fly(currentNode, BLOCKPOS_UP);
         }
-        if (currentNode.parent != null && isPassableBBDown(currentNode.parent.pos, currentNode.pos.down())) {
+        if (dPos.getY() <= 0) {
             fly(currentNode, BLOCKPOS_DOWN);
         }
+        /*if (currentNode.parent != null && isPassableBBDown(currentNode.parent.pos, currentNode.pos.down())) {
+            fly(currentNode, BLOCKPOS_DOWN);
+        }*/
 
 
         // Walk downwards node if passable

--- a/src/main/java/com/github/alexthe666/iceandfire/pathfinding/raycoms/pathjobs/PathJobRandomPos.java
+++ b/src/main/java/com/github/alexthe666/iceandfire/pathfinding/raycoms/pathjobs/PathJobRandomPos.java
@@ -93,7 +93,7 @@ public class PathJobRandomPos extends AbstractPathJob
     @Override
     protected boolean isAtDestination(final Node n)
     {
-        if (Math.sqrt(start.distanceSq(n.pos)) > distance && isWalkableSurface(world.getBlockState(n.pos.down()), n.pos.down()) == SurfaceType.WALKABLE)
+        if (Math.sqrt(start.distanceSq(n.pos)) > distance) //&& isWalkableSurface(world.getBlockState(n.pos.down()), n.pos.down()) == SurfaceType.WALKABLE)
         {
             getResult().randomPos = n.pos;
             return true;

--- a/src/main/java/com/github/alexthe666/iceandfire/pathfinding/raycoms/pathjobs/PathJobRandomPos.java
+++ b/src/main/java/com/github/alexthe666/iceandfire/pathfinding/raycoms/pathjobs/PathJobRandomPos.java
@@ -93,7 +93,7 @@ public class PathJobRandomPos extends AbstractPathJob
     @Override
     protected boolean isAtDestination(final Node n)
     {
-        if (Math.sqrt(start.distanceSq(n.pos)) > distance) //&& isWalkableSurface(world.getBlockState(n.pos.down()), n.pos.down()) == SurfaceType.WALKABLE)
+        if (Math.sqrt(start.distanceSq(n.pos)) > distance && isWalkableSurface(world.getBlockState(n.pos.down()), n.pos.down()) == SurfaceType.WALKABLE) //&& isWalkableSurface(world.getBlockState(n.pos.down()), n.pos.down()) == SurfaceType.WALKABLE)
         {
             getResult().randomPos = n.pos;
             return true;

--- a/src/main/java/com/github/alexthe666/iceandfire/world/IafWorldRegistry.java
+++ b/src/main/java/com/github/alexthe666/iceandfire/world/IafWorldRegistry.java
@@ -47,6 +47,7 @@ import net.minecraft.world.IWorld;
 import net.minecraft.world.biome.Biome;
 import net.minecraft.world.gen.DimensionSettings;
 import net.minecraft.world.gen.GenerationStage;
+import net.minecraft.world.gen.WorldGenRegion;
 import net.minecraft.world.gen.blockplacer.SimpleBlockPlacer;
 import net.minecraft.world.gen.blockstateprovider.SimpleBlockStateProvider;
 import net.minecraft.world.gen.feature.BlockClusterFeatureConfig;
@@ -301,8 +302,8 @@ public class IafWorldRegistry {
         }
     }
     public static boolean isFarEnoughFromDangerousGen(IWorld world, BlockPos pos) {
-        /*boolean canGen = true;
-        IafWorldData data = IafWorldData.get(world.getWorld());
+        boolean canGen = true;
+        IafWorldData data = IafWorldData.get(((WorldGenRegion) world).getWorld());
         if (data != null) {
             BlockPos last = data.lastGeneratedDangerousStructure;
             canGen = last.distanceSq(pos) > IafConfig.dangerousWorldGenSeparationLimit * IafConfig.dangerousWorldGenSeparationLimit;
@@ -310,8 +311,7 @@ public class IafWorldRegistry {
                 data.setLastGeneratedDangerousStructure(pos);
             }
         }
-        return canGen;*/
-        return true;
+        return canGen;
     }
 
     public static HashMap<String, Boolean> LOADED_FEATURES;

--- a/src/main/java/com/github/alexthe666/iceandfire/world/structure/MausoleumPiece.java
+++ b/src/main/java/com/github/alexthe666/iceandfire/world/structure/MausoleumPiece.java
@@ -43,11 +43,14 @@ public class MausoleumPiece {
         private final Random random;
         private final TemplateManager manager;
         private BlockPos firstPos = null;
-
+        private boolean offsetOnce = false;
         public boolean func_230383_a_(ISeedReader world, StructureManager p_230383_2_, ChunkGenerator p_230383_3_, Random p_230383_4_, MutableBoundingBox p_230383_5_, ChunkPos p_230383_6_, BlockPos p_230383_7_) {
-            p_230383_5_.expandTo(this.template.getMutableBoundingBox(this.placeSettings, this.templatePosition));
-            int i = world.getHeight(Heightmap.Type.WORLD_SURFACE_WG, firstPos.getX(), firstPos.getZ());
-            this.templatePosition = new BlockPos(this.templatePosition.getX(), i, this.templatePosition.getZ());
+            if(!offsetOnce) {
+                p_230383_5_.expandTo(this.template.getMutableBoundingBox(this.placeSettings, this.templatePosition));
+                int i = world.getHeight(Heightmap.Type.WORLD_SURFACE_WG, firstPos.getX(), firstPos.getZ());
+                this.templatePosition = new BlockPos(this.templatePosition.getX(), i, this.templatePosition.getZ());
+                offsetOnce = true;
+            }
             return super.func_230383_a_(world, p_230383_2_, p_230383_3_, p_230383_4_, p_230383_5_, p_230383_6_, p_230383_7_);
         }
 


### PR DESCRIPTION
Applies the following fixes:
    1. Hotfix for mausoleum generation being able to freeze the game indefinitely #3255
    2. Hotfix for reimplementing dangerous gen #3349
    3. Hotfix for lectern not using up manuscript pages #3324 

While 2. and 3. probably shouldn't be implemented like they are in the long term (especially since 2. is using a deprecated method) these could server as a nice stepping stone.
These changes work both with the 1.6.3 forge version as well forge 35.1.28

Note: #3255 is not the same as #3260 and similar issues those hangups still persist and are probably tied to the dragons.