### PR TITLE
1.16.3 Throwable Egg Entity Fixes

### DIFF
--- a/src/main/java/com/github/alexthe666/iceandfire/entity/EntityCockatriceEgg.java
+++ b/src/main/java/com/github/alexthe666/iceandfire/entity/EntityCockatriceEgg.java
@@ -41,8 +41,6 @@ public class EntityCockatriceEgg extends ProjectileItemEntity {
     @OnlyIn(Dist.CLIENT)
     public void handleStatusUpdate(byte id) {
         if (id == 3) {
-            double d0 = 0.08D;
-
             for (int i = 0; i < 8; ++i) {
                 this.world.addParticle(new ItemParticleData(ParticleTypes.ITEM, this.getItem()), this.getPosX(), this.getPosY(), this.getPosZ(), ((double) this.rand.nextFloat() - 0.5D) * 0.08D, ((double) this.rand.nextFloat() - 0.5D) * 0.08D, ((double) this.rand.nextFloat() - 0.5D) * 0.08D);
             }
@@ -54,9 +52,9 @@ public class EntityCockatriceEgg extends ProjectileItemEntity {
      * Called when this EntityThrowable hits a block or entity.
      */
     protected void onImpact(RayTraceResult result) {
+        Entity thrower = func_234616_v_();
         if (result.getType() == RayTraceResult.Type.ENTITY) {
-
-            ((EntityRayTraceResult) result).getEntity().attackEntityFrom(DamageSource.causeThrownDamage(this, this.func_234616_v_()), 0.0F);
+            ((EntityRayTraceResult) result).getEntity().attackEntityFrom(DamageSource.causeThrownDamage(this, thrower), 0.0F);
         }
 
         if (!this.world.isRemote) {
@@ -72,8 +70,7 @@ public class EntityCockatriceEgg extends ProjectileItemEntity {
                     cockatrice.setGrowingAge(-24000);
                     cockatrice.setHen(this.rand.nextBoolean());
                     cockatrice.setLocationAndAngles(this.getPosX(), this.getPosY(), this.getPosZ(), this.rotationYaw, 0.0F);
-                    Entity thrower = func_234616_v_();
-                    if (thrower != null && thrower instanceof PlayerEntity) {
+                    if (thrower instanceof PlayerEntity) {
                         cockatrice.setTamedBy((PlayerEntity) thrower);
                     }
                     this.world.addEntity(cockatrice);

--- a/src/main/java/com/github/alexthe666/iceandfire/entity/EntityDeathWormEgg.java
+++ b/src/main/java/com/github/alexthe666/iceandfire/entity/EntityDeathWormEgg.java
@@ -75,12 +75,14 @@ public class EntityDeathWormEgg extends ProjectileItemEntity implements IEntityA
         }
 
         if (!this.world.isRemote) {
+            float wormSize = 0.25F + (float) (Math.random() * 0.35F);
+
             EntityDeathWorm deathworm = new EntityDeathWorm(IafEntityRegistry.DEATH_WORM, this.world);
             deathworm.setVariant(new Random().nextInt(3));
             deathworm.setTamed(true);
             deathworm.setWormHome(func_233580_cy_());
             deathworm.setWormAge(1);
-            deathworm.setDeathWormScale(giant ? (0.25F + (float) (Math.random() * 0.35F)) * 4 : 0.25F + (float) (Math.random() * 0.35F));
+            deathworm.setDeathWormScale(giant ? (wormSize * 4) : wormSize);
             deathworm.setLocationAndAngles(this.getPosX(), this.getPosY(), this.getPosZ(), this.rotationYaw, 0.0F);
             if (thrower instanceof PlayerEntity) {
                 deathworm.setOwnerId(thrower.getUniqueID());

--- a/src/main/java/com/github/alexthe666/iceandfire/entity/EntityDeathWormEgg.java
+++ b/src/main/java/com/github/alexthe666/iceandfire/entity/EntityDeathWormEgg.java
@@ -7,6 +7,7 @@ import com.github.alexthe666.iceandfire.item.IafItemRegistry;
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.EntityType;
 import net.minecraft.entity.LivingEntity;
+import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.entity.projectile.ProjectileItemEntity;
 import net.minecraft.item.Item;
 import net.minecraft.network.IPacket;
@@ -70,20 +71,22 @@ public class EntityDeathWormEgg extends ProjectileItemEntity implements IEntityA
     protected void onImpact(RayTraceResult result) {
         Entity thrower = func_234616_v_();
         if (result.getType() == RayTraceResult.Type.ENTITY) {
-
             ((EntityRayTraceResult) result).getEntity().attackEntityFrom(DamageSource.causeThrownDamage(this, thrower), 0.0F);
         }
 
-        if (!this.world.isRemote && thrower != null) {
+        if (!this.world.isRemote) {
             EntityDeathWorm deathworm = new EntityDeathWorm(IafEntityRegistry.DEATH_WORM, this.world);
             deathworm.setVariant(new Random().nextInt(3));
             deathworm.setTamed(true);
             deathworm.setWormHome(func_233580_cy_());
             deathworm.setWormAge(1);
             deathworm.setDeathWormScale(giant ? (0.25F + (float) (Math.random() * 0.35F)) * 4 : 0.25F + (float) (Math.random() * 0.35F));
-            deathworm.setOwnerId(thrower.getUniqueID());
             deathworm.setLocationAndAngles(this.getPosX(), this.getPosY(), this.getPosZ(), this.rotationYaw, 0.0F);
+            if (thrower instanceof PlayerEntity) {
+                deathworm.setOwnerId(thrower.getUniqueID());
+            }
             this.world.addEntity(deathworm);
+
             this.world.setEntityState(this, (byte) 3);
             this.remove();
         }

--- a/src/main/java/com/github/alexthe666/iceandfire/entity/EntityDeathWormEgg.java
+++ b/src/main/java/com/github/alexthe666/iceandfire/entity/EntityDeathWormEgg.java
@@ -9,8 +9,8 @@ import net.minecraft.entity.EntityType;
 import net.minecraft.entity.LivingEntity;
 import net.minecraft.entity.projectile.ProjectileItemEntity;
 import net.minecraft.item.Item;
-import net.minecraft.item.ItemStack;
 import net.minecraft.network.IPacket;
+import net.minecraft.network.PacketBuffer;
 import net.minecraft.particles.ItemParticleData;
 import net.minecraft.particles.ParticleTypes;
 import net.minecraft.util.DamageSource;
@@ -19,9 +19,10 @@ import net.minecraft.util.math.RayTraceResult;
 import net.minecraft.world.World;
 import net.minecraftforge.api.distmarker.Dist;
 import net.minecraftforge.api.distmarker.OnlyIn;
+import net.minecraftforge.fml.common.registry.IEntityAdditionalSpawnData;
 import net.minecraftforge.fml.network.NetworkHooks;
 
-public class EntityDeathWormEgg extends ProjectileItemEntity {
+public class EntityDeathWormEgg extends ProjectileItemEntity implements IEntityAdditionalSpawnData {
 
     private boolean giant;
 
@@ -44,30 +45,23 @@ public class EntityDeathWormEgg extends ProjectileItemEntity {
         return NetworkHooks.getEntitySpawningPacket(this);
     }
 
+    @Override
+    public void writeSpawnData(PacketBuffer buffer) {
+        buffer.writeBoolean(this.giant);
+    }
 
     @Override
-    protected void registerData() {
-
+    public void readSpawnData(PacketBuffer additionalData) {
+        this.giant = additionalData.readBoolean();
     }
 
     @OnlyIn(Dist.CLIENT)
     public void handleStatusUpdate(byte id) {
         if (id == 3) {
-            double d0 = 0.08D;
-
             for (int i = 0; i < 8; ++i) {
                 this.world.addParticle(new ItemParticleData(ParticleTypes.ITEM, this.getItem()), this.getPosX(), this.getPosY(), this.getPosZ(), ((double) this.rand.nextFloat() - 0.5D) * 0.08D, ((double) this.rand.nextFloat() - 0.5D) * 0.08D, ((double) this.rand.nextFloat() - 0.5D) * 0.08D);
             }
         }
-
-    }
-
-    protected Item getDefaultItem() {
-        return giant ? IafItemRegistry.DEATHWORM_EGG_GIGANTIC : IafItemRegistry.DEATHWORM_EGG;
-    }
-
-    protected ItemStack func_213882_k() {
-        return new ItemStack(getDefaultItem());
     }
 
     /**
@@ -93,5 +87,10 @@ public class EntityDeathWormEgg extends ProjectileItemEntity {
             this.world.setEntityState(this, (byte) 3);
             this.remove();
         }
+    }
+
+    @Override
+    protected Item getDefaultItem() {
+        return giant ? IafItemRegistry.DEATHWORM_EGG_GIGANTIC : IafItemRegistry.DEATHWORM_EGG;
     }
 }

--- a/src/main/java/com/github/alexthe666/iceandfire/entity/EntityHippogryphEgg.java
+++ b/src/main/java/com/github/alexthe666/iceandfire/entity/EntityHippogryphEgg.java
@@ -5,8 +5,10 @@ import com.github.alexthe666.iceandfire.item.IafItemRegistry;
 import net.minecraft.entity.EntityType;
 import net.minecraft.entity.LivingEntity;
 import net.minecraft.entity.projectile.EggEntity;
+import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.CompoundNBT;
+import net.minecraft.network.IPacket;
 import net.minecraft.particles.ItemParticleData;
 import net.minecraft.particles.ParticleTypes;
 import net.minecraft.util.DamageSource;
@@ -15,6 +17,7 @@ import net.minecraft.util.math.RayTraceResult;
 import net.minecraft.world.World;
 import net.minecraftforge.api.distmarker.Dist;
 import net.minecraftforge.api.distmarker.OnlyIn;
+import net.minecraftforge.fml.network.NetworkHooks;
 
 public class EntityHippogryphEgg extends EggEntity {
 
@@ -36,11 +39,16 @@ public class EntityHippogryphEgg extends EggEntity {
         this.itemstack = stack;
     }
 
+    @Override
+    public IPacket<?> createSpawnPacket() {
+        return NetworkHooks.getEntitySpawningPacket(this);
+    }
+
     @OnlyIn(Dist.CLIENT)
     public void handleStatusUpdate(byte id) {
         if (id == 3) {
             for (int i = 0; i < 8; ++i) {
-                this.world.addParticle(new ItemParticleData(ParticleTypes.ITEM, new ItemStack(IafItemRegistry.HIPPOGRYPH_EGG)), this.getPosX(), this.getPosY(), this.getPosZ(), ((double) this.rand.nextFloat() - 0.5D) * 0.08D, ((double) this.rand.nextFloat() - 0.5D) * 0.08D, ((double) this.rand.nextFloat() - 0.5D) * 0.08D);
+                this.world.addParticle(new ItemParticleData(ParticleTypes.ITEM, this.getItem()), this.getPosX(), this.getPosY(), this.getPosZ(), ((double) this.rand.nextFloat() - 0.5D) * 0.08D, ((double) this.rand.nextFloat() - 0.5D) * 0.08D, ((double) this.rand.nextFloat() - 0.5D) * 0.08D);
             }
         }
     }
@@ -67,5 +75,10 @@ public class EntityHippogryphEgg extends EggEntity {
 
         this.world.setEntityState(this, (byte) 3);
         this.remove();
+    }
+
+    @Override
+    protected Item getDefaultItem() {
+      return IafItemRegistry.HIPPOGRYPH_EGG;
     }
 }

--- a/src/main/java/com/github/alexthe666/iceandfire/entity/EntityHippogryphEgg.java
+++ b/src/main/java/com/github/alexthe666/iceandfire/entity/EntityHippogryphEgg.java
@@ -2,6 +2,7 @@ package com.github.alexthe666.iceandfire.entity;
 
 import com.github.alexthe666.iceandfire.item.IafItemRegistry;
 
+import net.minecraft.entity.Entity;
 import net.minecraft.entity.EntityType;
 import net.minecraft.entity.LivingEntity;
 import net.minecraft.entity.projectile.EggEntity;
@@ -54,8 +55,9 @@ public class EntityHippogryphEgg extends EggEntity {
     }
 
     protected void onImpact(RayTraceResult result) {
+        Entity thrower = func_234616_v_();
         if (result.getType() == RayTraceResult.Type.ENTITY) {
-            ((EntityRayTraceResult) result).getEntity().attackEntityFrom(DamageSource.causeThrownDamage(this, this.func_234616_v_()), 0.0F);
+            ((EntityRayTraceResult) result).getEntity().attackEntityFrom(DamageSource.causeThrownDamage(this, thrower), 0.0F);
         }
 
         if (!this.world.isRemote) {

--- a/src/main/java/com/github/alexthe666/iceandfire/item/ItemDeathwormEgg.java
+++ b/src/main/java/com/github/alexthe666/iceandfire/item/ItemDeathwormEgg.java
@@ -15,7 +15,7 @@ import net.minecraft.util.SoundEvents;
 import net.minecraft.world.World;
 
 public class ItemDeathwormEgg extends Item implements ICustomRendered {
-    private boolean gigantic;
+    private final boolean gigantic;
 
     public ItemDeathwormEgg(boolean gigantic) {
         super(new Item.Properties().group(IceAndFire.TAB_ITEMS).maxStackSize(1));
@@ -39,6 +39,6 @@ public class ItemDeathwormEgg extends Item implements ICustomRendered {
             worldIn.addEntity(entityegg);
         }
 
-        return new ActionResult<ItemStack>(ActionResultType.SUCCESS, itemstack);
+        return new ActionResult<>(ActionResultType.SUCCESS, itemstack);
     }
 }

--- a/src/main/java/com/github/alexthe666/iceandfire/item/ItemDeathwormEgg.java
+++ b/src/main/java/com/github/alexthe666/iceandfire/item/ItemDeathwormEgg.java
@@ -35,7 +35,7 @@ public class ItemDeathwormEgg extends Item implements ICustomRendered {
 
         if (!worldIn.isRemote) {
             EntityDeathWormEgg entityegg = new EntityDeathWormEgg(IafEntityRegistry.DEATH_WORM_EGG, playerIn, worldIn, gigantic);
-            entityegg.shoot( playerIn.rotationPitch, playerIn.rotationYaw, 0.0F, 1.5F, 1.0F);
+            entityegg.func_234612_a_(playerIn, playerIn.rotationPitch, playerIn.rotationYaw, 0.0F, 1.5F, 1.0F);
             worldIn.addEntity(entityegg);
         }
 

--- a/src/main/java/com/github/alexthe666/iceandfire/item/ItemHippogryphEgg.java
+++ b/src/main/java/com/github/alexthe666/iceandfire/item/ItemHippogryphEgg.java
@@ -75,7 +75,7 @@ public class ItemHippogryphEgg extends Item implements ICustomRendered {
             worldIn.addEntity(entityegg);
         }
 
-        return new ActionResult(ActionResultType.SUCCESS, itemstack);
+        return new ActionResult<>(ActionResultType.SUCCESS, itemstack);
     }
 
     @Override

--- a/src/main/java/com/github/alexthe666/iceandfire/item/ItemRottenEgg.java
+++ b/src/main/java/com/github/alexthe666/iceandfire/item/ItemRottenEgg.java
@@ -36,6 +36,6 @@ public class ItemRottenEgg extends Item {
             worldIn.addEntity(entityegg);
         }
 
-        return new ActionResult(ActionResultType.SUCCESS, itemstack);
+        return new ActionResult<>(ActionResultType.SUCCESS, itemstack);
     }
 }

--- a/src/main/java/com/github/alexthe666/iceandfire/recipe/IafRecipeRegistry.java
+++ b/src/main/java/com/github/alexthe666/iceandfire/recipe/IafRecipeRegistry.java
@@ -124,8 +124,7 @@ public class IafRecipeRegistry {
              * Return the projectile entity spawned by this dispense behavior.
              */
             protected ProjectileEntity getProjectileEntity(World worldIn, IPosition position, ItemStack stackIn) {
-                EntityHippogryphEgg entityarrow = new EntityHippogryphEgg(IafEntityRegistry.HIPPOGRYPH_EGG, worldIn, position.getX(), position.getY(), position.getZ(), stackIn);
-                return entityarrow;
+                return new EntityHippogryphEgg(IafEntityRegistry.HIPPOGRYPH_EGG, worldIn, position.getX(), position.getY(), position.getZ(), stackIn);
             }
         });
         DispenserBlock.registerDispenseBehavior(IafItemRegistry.ROTTEN_EGG, new ProjectileDispenseBehavior() {
@@ -133,8 +132,7 @@ public class IafRecipeRegistry {
              * Return the projectile entity spawned by this dispense behavior.
              */
             protected ProjectileEntity getProjectileEntity(World worldIn, IPosition position, ItemStack stackIn) {
-                EntityCockatriceEgg entityarrow = new EntityCockatriceEgg(IafEntityRegistry.COCKATRICE_EGG, position.getX(), position.getY(), position.getZ(), worldIn);
-                return entityarrow;
+                return new EntityCockatriceEgg(IafEntityRegistry.COCKATRICE_EGG, position.getX(), position.getY(), position.getZ(), worldIn);
             }
         });
         DispenserBlock.registerDispenseBehavior(IafItemRegistry.DEATHWORM_EGG, new ProjectileDispenseBehavior() {
@@ -142,8 +140,7 @@ public class IafRecipeRegistry {
              * Return the projectile entity spawned by this dispense behavior.
              */
             protected ProjectileEntity getProjectileEntity(World worldIn, IPosition position, ItemStack stackIn) {
-                EntityDeathWormEgg entityarrow = new EntityDeathWormEgg(IafEntityRegistry.DEATH_WORM_EGG, position.getX(), position.getY(), position.getZ(), worldIn, false);
-                return entityarrow;
+                return new EntityDeathWormEgg(IafEntityRegistry.DEATH_WORM_EGG, position.getX(), position.getY(), position.getZ(), worldIn, false);
             }
         });
         DispenserBlock.registerDispenseBehavior(IafItemRegistry.DEATHWORM_EGG_GIGANTIC, new ProjectileDispenseBehavior() {
@@ -151,8 +148,7 @@ public class IafRecipeRegistry {
              * Return the projectile entity spawned by this dispense behavior.
              */
             protected ProjectileEntity getProjectileEntity(World worldIn, IPosition position, ItemStack stackIn) {
-                EntityDeathWormEgg entityarrow = new EntityDeathWormEgg(IafEntityRegistry.DEATH_WORM_EGG, position.getX(), position.getY(), position.getZ(), worldIn, true);
-                return entityarrow;
+                return new EntityDeathWormEgg(IafEntityRegistry.DEATH_WORM_EGG, position.getX(), position.getY(), position.getZ(), worldIn, true);
             }
         });
         /*


### PR DESCRIPTION
Fixes the following issues:
1. Thrown Hippogryph egg not rendering client side
2. Deathworm egg being launched in the wrong direction
3. Thrown Giant Deathworm egg rendering as regular egg client side
4. Deathworms not spawning from eggs launched by dispensers

This will likely fix most / all of the bugs reported in #3328