### PR TITLE
no more "death.attack.stuck-damage"

### DIFF
--- a/src/main/java/com/github/alexthe666/iceandfire/pathfinding/raycoms/PathingStuckHandler.java
+++ b/src/main/java/com/github/alexthe666/iceandfire/pathfinding/raycoms/PathingStuckHandler.java
@@ -236,10 +236,10 @@ public class PathingStuckHandler implements IStuckHandler
                 }
             }
         }
-        if (takeDamageOnCompleteStuck)
+        /*if (takeDamageOnCompleteStuck)
         {
             entity.attackEntityFrom(new EntityDamageSource("Stuck-damage", entity), entity.getMaxHealth() * damagePct);
-        }
+        }*/
 
         if (completeStuckBlockBreakRange > 0)
         {


### PR DESCRIPTION
when an Ice and Fire mob gets stuck, they are damage by 20% of their max HP.
if the mob is tamed and dies, the owner is sent the message "death.attack.stuck-damage"
the solution is to disable the block of code that damages stuck entities.