### PR TITLE
Thaumcraft Compat: crash when used with Thaumic Additions: Reconstructed (regarding the aspect "Draco")

### DIFF
--- a/src/main/java/com/github/alexthe666/iceandfire/IceAndFire.java
+++ b/src/main/java/com/github/alexthe666/iceandfire/IceAndFire.java
@@ -47,7 +47,7 @@ import java.io.File;
 import java.util.Random;
 
 @Mod(modid = IceAndFire.MODID,
-        dependencies = "required-after:llibrary@[" + IceAndFire.LLIBRARY_VERSION + ",)",
+        dependencies = "required-after:llibrary@[" + IceAndFire.LLIBRARY_VERSION + ",);after:thaumicadds",
         version = IceAndFire.VERSION, name = IceAndFire.NAME, guiFactory = "com.github.alexthe666.iceandfire.client.gui.IceAndFireGuiFactory")
 public class IceAndFire {
 


### PR DESCRIPTION
Ice and Fire already has `getOrCreateAspect` but it wasn't being used as Ice and Fire was loaded first unless the .jar file was renamed to be alphabetically later than Additions'.

Tested.