### PR TITLE
(1.16) Optimize and improve enums

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -122,7 +122,6 @@ dependencies {
     compileOnly fg.deobf("mezz.jei:jei-1.16.2:7.1.3.19:api")
     runtimeOnly fg.deobf("mezz.jei:jei-1.16.2:7.1.3.19")
     implementation "curse.maven:citadel-331936:3441030"
-
 }
 
 // Example for how to get properties into the manifest for reading by the runtime..

--- a/src/main/java/com/github/alexthe666/iceandfire/client/gui/bestiary/GuiBestiary.java
+++ b/src/main/java/com/github/alexthe666/iceandfire/client/gui/bestiary/GuiBestiary.java
@@ -1,7 +1,12 @@
 package com.github.alexthe666.iceandfire.client.gui.bestiary;
 
 import java.io.IOException;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Set;
 
 import org.apache.commons.io.IOUtils;
 import org.lwjgl.opengl.GL11;
@@ -18,6 +23,7 @@ import com.github.alexthe666.iceandfire.enums.EnumTroll;
 import com.github.alexthe666.iceandfire.item.IafItemRegistry;
 import com.github.alexthe666.iceandfire.misc.IafSoundRegistry;
 import com.google.common.collect.Maps;
+import com.google.common.primitives.Ints;
 import com.mojang.blaze3d.matrix.MatrixStack;
 import com.mojang.blaze3d.platform.GlStateManager;
 import com.mojang.blaze3d.systems.RenderSystem;
@@ -40,6 +46,7 @@ import net.minecraft.item.Items;
 import net.minecraft.resources.IResource;
 import net.minecraft.util.ResourceLocation;
 import net.minecraft.util.text.TranslationTextComponent;
+
 import net.minecraftforge.api.distmarker.Dist;
 import net.minecraftforge.api.distmarker.OnlyIn;
 import net.minecraftforge.registries.ForgeRegistries;
@@ -69,10 +76,10 @@ public class GuiBestiary extends Screen {
     public GuiBestiary(ItemStack book) {
         super(new TranslationTextComponent("bestiary_gui"));
         this.book = book;
-        int indexPageTotal = 0;
         if (!book.isEmpty() && book.getItem() != null && book.getItem() == IafItemRegistry.BESTIARY) {
             if (book.getTag() != null) {
-                List<EnumBestiaryPages> pages = EnumBestiaryPages.containedPages(EnumBestiaryPages.toList(book.getTag().getIntArray("Pages")));
+                Set<EnumBestiaryPages> pages = EnumBestiaryPages
+                    .containedPages(Ints.asList(book.getTag().getIntArray("Pages")));
                 allPageTypes.addAll(pages);
                 indexPagesTotal = (int) Math.ceil(pages.size() / 10D);
             }
@@ -90,6 +97,7 @@ public class GuiBestiary extends Screen {
         return font;
     }
 
+    @Override
     protected void init() {
         super.init();
         int centerX = (width - X) / 2;
@@ -975,7 +983,7 @@ public class GuiBestiary extends Screen {
         RenderSystem.blendFunc(GlStateManager.SourceFactor.SRC_ALPHA, GlStateManager.DestFactor.ONE_MINUS_SRC_ALPHA);
         RenderSystem.scalef(16.0F * scale, 16.0F * scale, 16.0F * scale);
         RenderSystem.color4f(1.0F, 1.0F, 1.0F, 1.0F);
-        RenderSystem.translatef((float)x, (float)y , 100.0F + itemRenderer.zLevel);
+        RenderSystem.translatef(x, y , 100.0F + itemRenderer.zLevel);
         RenderSystem.scalef(1.0F, -1.0F, 1.0F);
         MatrixStack matrixstack = new MatrixStack();
         IRenderTypeBuffer.Impl irendertypebuffer$impl = Minecraft.getInstance().getRenderTypeBuffers().getBufferSource();

--- a/src/main/java/com/github/alexthe666/iceandfire/enums/EnumBestiaryPages.java
+++ b/src/main/java/com/github/alexthe666/iceandfire/enums/EnumBestiaryPages.java
@@ -7,6 +7,7 @@ import java.util.List;
 import java.util.Set;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 
 import javax.annotation.Nullable;
 
@@ -48,6 +49,8 @@ public enum EnumBestiaryPages {
     GHOST(1);
 
     public static final ImmutableList<EnumBestiaryPages> ALL_PAGES = ImmutableList.copyOf(EnumBestiaryPages.values());
+    public static final ImmutableList<Integer> ALL_INDEXES = ImmutableList
+        .copyOf(IntStream.range(0, EnumBestiaryPages.values().length).iterator());
 
     public int pages;
 
@@ -60,7 +63,7 @@ public enum EnumBestiaryPages {
     }
 
     public static boolean hasAllPages(ItemStack book) {
-        return containedPages(Ints.asList(book.getTag().getIntArray("Pages"))).containsAll(ALL_PAGES);
+        return Ints.asList(book.getTag().getIntArray("Pages")).containsAll(ALL_INDEXES);
     }
 
     public static List<Integer> enumToInt(List<EnumBestiaryPages> pages) {

--- a/src/main/java/com/github/alexthe666/iceandfire/enums/EnumDragonEgg.java
+++ b/src/main/java/com/github/alexthe666/iceandfire/enums/EnumDragonEgg.java
@@ -1,40 +1,29 @@
 package com.github.alexthe666.iceandfire.enums;
 
-import java.util.Map;
-
 import com.github.alexthe666.iceandfire.entity.DragonType;
-import com.google.common.collect.Maps;
 
 import net.minecraft.util.text.TextFormatting;
 
 public enum EnumDragonEgg {
-    RED(0, TextFormatting.DARK_RED, DragonType.FIRE), GREEN(1, TextFormatting.DARK_GREEN, DragonType.FIRE), BRONZE(2, TextFormatting.GOLD, DragonType.FIRE), GRAY(3, TextFormatting.GRAY, DragonType.FIRE),
-    BLUE(4, TextFormatting.AQUA, DragonType.ICE), WHITE(5, TextFormatting.WHITE, DragonType.ICE), SAPPHIRE(6, TextFormatting.BLUE, DragonType.ICE), SILVER(7, TextFormatting.DARK_GRAY, DragonType.ICE),
-    ELECTRIC(8, TextFormatting.DARK_BLUE, DragonType.LIGHTNING), AMYTHEST(9, TextFormatting.LIGHT_PURPLE, DragonType.LIGHTNING), COPPER(10, TextFormatting.GOLD, DragonType.LIGHTNING), BLACK(11, TextFormatting.DARK_GRAY, DragonType.LIGHTNING);
 
-    private static final Map<Integer, EnumDragonEgg> META_LOOKUP = Maps.newHashMap();
+    RED(TextFormatting.DARK_RED, DragonType.FIRE), GREEN(TextFormatting.DARK_GREEN, DragonType.FIRE),
+    BRONZE(TextFormatting.GOLD, DragonType.FIRE), GRAY(TextFormatting.GRAY, DragonType.FIRE),
+    BLUE(TextFormatting.AQUA, DragonType.ICE), WHITE(TextFormatting.WHITE, DragonType.ICE),
+    SAPPHIRE(TextFormatting.BLUE, DragonType.ICE), SILVER(TextFormatting.DARK_GRAY, DragonType.ICE),
+    ELECTRIC(TextFormatting.DARK_BLUE, DragonType.LIGHTNING),
+    AMYTHEST(TextFormatting.LIGHT_PURPLE, DragonType.LIGHTNING), COPPER(TextFormatting.GOLD, DragonType.LIGHTNING),
+    BLACK(TextFormatting.DARK_GRAY, DragonType.LIGHTNING);
 
-    static {
-        EnumDragonEgg[] var0 = values();
-        int var1 = var0.length;
-
-        for (EnumDragonEgg var3 : var0) {
-            META_LOOKUP.put(var3.meta, var3);
-        }
-    }
-
-    public int meta;
     public TextFormatting color;
     public DragonType dragonType;
 
-    EnumDragonEgg(int meta, TextFormatting color, DragonType dragonType) {
-        this.meta = meta;
+    EnumDragonEgg(TextFormatting color, DragonType dragonType) {
         this.color = color;
         this.dragonType = dragonType;
     }
 
     public static EnumDragonEgg byMetadata(int meta) {
-        EnumDragonEgg i = META_LOOKUP.get(meta);
+        EnumDragonEgg i = values()[meta];
         return i == null ? RED : i;
     }
 }

--- a/src/main/java/com/github/alexthe666/iceandfire/enums/EnumHippogryphTypes.java
+++ b/src/main/java/com/github/alexthe666/iceandfire/enums/EnumHippogryphTypes.java
@@ -3,7 +3,7 @@ package com.github.alexthe666.iceandfire.enums;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
-import java.util.Random;
+import java.util.concurrent.ThreadLocalRandom;
 
 import com.github.alexthe666.iceandfire.config.BiomeConfig;
 
@@ -38,11 +38,11 @@ public enum EnumHippogryphTypes {
     }
 
     public static EnumHippogryphTypes getRandomType() {
-        return getWildTypes()[new Random().nextInt(getWildTypes().length - 1)];
+        return getWildTypes()[ThreadLocalRandom.current().nextInt(getWildTypes().length - 1)];
     }
 
     public static EnumHippogryphTypes getBiomeType(Biome biome) {
-        List<EnumHippogryphTypes> types = new ArrayList<EnumHippogryphTypes>();
+        List<EnumHippogryphTypes> types = new ArrayList<>();
         if (BiomeConfig.test(BiomeConfig.blackHippogryphBiomes, biome)) {
             types.add(BLACK);
         }
@@ -70,7 +70,7 @@ public enum EnumHippogryphTypes {
             if (types.contains(GRAY) && types.contains(CHESTNUT)) {
                 return GRAY;
             }
-            return types.get(new Random().nextInt(types.size()));
+            return types.get(ThreadLocalRandom.current().nextInt(types.size()));
         }
 
     }

--- a/src/main/java/com/github/alexthe666/iceandfire/enums/EnumTroll.java
+++ b/src/main/java/com/github/alexthe666/iceandfire/enums/EnumTroll.java
@@ -3,7 +3,7 @@ package com.github.alexthe666.iceandfire.enums;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
-import java.util.Random;
+import java.util.concurrent.ThreadLocalRandom;
 
 import com.github.alexthe666.citadel.server.item.CustomArmorMaterial;
 import com.github.alexthe666.iceandfire.config.BiomeConfig;
@@ -17,7 +17,6 @@ import net.minecraft.item.IArmorMaterial;
 import net.minecraft.item.Item;
 import net.minecraft.util.ResourceLocation;
 import net.minecraft.world.biome.Biome;
-
 
 public enum EnumTroll {
     FOREST(IafItemRegistry.TROLL_FOREST_ARMOR_MATERIAL, Weapon.TRUNK, Weapon.COLUMN_FOREST, Weapon.AXE, Weapon.HAMMER),
@@ -50,7 +49,7 @@ public enum EnumTroll {
     }
 
     public static EnumTroll getBiomeType(Biome biome) {
-        List<EnumTroll> types = new ArrayList<EnumTroll>();
+        List<EnumTroll> types = new ArrayList<>();
         if (BiomeConfig.test(BiomeConfig.snowyTrollBiomes, biome)) {
             types.add(EnumTroll.FROST);
         }
@@ -61,15 +60,15 @@ public enum EnumTroll {
             types.add(EnumTroll.MOUNTAIN);
         }
         if (types.isEmpty()) {
-            return values()[new Random().nextInt(values().length)];
+            return values()[ThreadLocalRandom.current().nextInt(values().length)];
         } else {
-            return types.get(new Random().nextInt(types.size()));
+            return types.get(ThreadLocalRandom.current().nextInt(types.size()));
         }
     }
 
 
     public static Weapon getWeaponForType(EnumTroll troll) {
-        return troll.weapons[new Random().nextInt(troll.weapons.length)];
+        return troll.weapons[ThreadLocalRandom.current().nextInt(troll.weapons.length)];
     }
 
     public enum Weapon {

--- a/src/main/java/com/github/alexthe666/iceandfire/item/ItemBestiary.java
+++ b/src/main/java/com/github/alexthe666/iceandfire/item/ItemBestiary.java
@@ -1,11 +1,13 @@
 package com.github.alexthe666.iceandfire.item;
 
 import java.util.List;
+import java.util.Set;
 
 import javax.annotation.Nullable;
 
 import com.github.alexthe666.iceandfire.IceAndFire;
 import com.github.alexthe666.iceandfire.enums.EnumBestiaryPages;
+import com.google.common.primitives.Ints;
 
 import net.minecraft.client.util.ITooltipFlag;
 import net.minecraft.entity.Entity;
@@ -38,6 +40,7 @@ public class ItemBestiary extends Item {
 
     }
 
+    @Override
     public void fillItemGroup(ItemGroup group, NonNullList<ItemStack> items) {
         if (this.isInGroup(group)) {
             items.add(new ItemStack(this));
@@ -58,7 +61,7 @@ public class ItemBestiary extends Item {
         if (worldIn.isRemote) {
             IceAndFire.PROXY.openBestiaryGui(itemStackIn);
         }
-        return new ActionResult<ItemStack>(ActionResultType.PASS, itemStackIn);
+        return new ActionResult<>(ActionResultType.PASS, itemStackIn);
     }
 
     @Override
@@ -75,7 +78,8 @@ public class ItemBestiary extends Item {
         if (stack.getTag() != null) {
             if (IceAndFire.PROXY.shouldSeeBestiaryContents()) {
                 tooltip.add(new TranslationTextComponent("bestiary.contains").mergeStyle(TextFormatting.GRAY));
-                List<EnumBestiaryPages> pages = EnumBestiaryPages.containedPages(EnumBestiaryPages.toList(stack.getTag().getIntArray("Pages")));
+                final Set<EnumBestiaryPages> pages = EnumBestiaryPages
+                    .containedPages(Ints.asList(stack.getTag().getIntArray("Pages")));
                 for (EnumBestiaryPages page : pages) {
                     tooltip.add(new StringTextComponent(TextFormatting.WHITE + "-").appendSibling(new TranslationTextComponent("bestiary." + EnumBestiaryPages.values()[page.ordinal()].toString().toLowerCase())).mergeStyle(TextFormatting.GRAY));
                 }


### PR DESCRIPTION
This PR improves the performance of the methods in the different enums, especially the ones in `EnumBestiaryPages`:
- `new Random()`s are replaced with `ThreadLocalRandom.current()` 
- useless `Map<Integer, Enum>`s are removed, in favour of `Enum.values()`
- integers are no longer uselessly converted to an enum, and later, converted to their int representation
- the method `EnumBestiaryPages#hasAllPages` now uses `Collection#containsAll(Collection)`, and _works_ (before the method didn't work, as it returned too early)
# ForgeGradle is also updated to 5+.