### PR TITLE
(1.16) Move IafTileEntityRegistry to DeferredRegister

### DIFF
--- a/src/main/java/com/github/alexthe666/iceandfire/ClientProxy.java
+++ b/src/main/java/com/github/alexthe666/iceandfire/ClientProxy.java
@@ -280,14 +280,15 @@ public class ClientProxy extends CommonProxy {
         RenderingRegistry.registerEntityRenderingHandler(IafEntityRegistry.HYDRA_MULTIPART, manager -> new RenderNothing(manager));
         RenderingRegistry.registerEntityRenderingHandler(IafEntityRegistry.GHOST, manager -> new RenderGhost(manager));
         RenderingRegistry.registerEntityRenderingHandler(IafEntityRegistry.GHOST_SWORD, manager -> new RenderGhostSword(manager));
-        ClientRegistry.bindTileEntityRenderer(IafTileEntityRegistry.PODIUM, manager -> new RenderPodium(manager));
-        ClientRegistry.bindTileEntityRenderer(IafTileEntityRegistry.IAF_LECTERN, manager -> new RenderLectern(manager));
-        ClientRegistry.bindTileEntityRenderer(IafTileEntityRegistry.EGG_IN_ICE, manager -> new RenderEggInIce(manager));
-        ClientRegistry.bindTileEntityRenderer(IafTileEntityRegistry.PIXIE_HOUSE, manager -> new RenderPixieHouse(manager));
-        ClientRegistry.bindTileEntityRenderer(IafTileEntityRegistry.PIXIE_JAR, manager -> new RenderJar(manager));
-        ClientRegistry.bindTileEntityRenderer(IafTileEntityRegistry.DREAD_PORTAL, manager -> new RenderDreadPortal(manager));
-        ClientRegistry.bindTileEntityRenderer(IafTileEntityRegistry.DREAD_SPAWNER, manager -> new RenderDreadSpawner(manager));
-        ClientRegistry.bindTileEntityRenderer(IafTileEntityRegistry.GHOST_CHEST, manager -> new RenderGhostChest(manager));
+        //@formatter:off
+        ClientRegistry.bindTileEntityRenderer(IafTileEntityRegistry.PODIUM.get(), manager -> new RenderPodium(manager));
+        ClientRegistry.bindTileEntityRenderer(IafTileEntityRegistry.IAF_LECTERN.get(), manager -> new RenderLectern(manager));
+        ClientRegistry.bindTileEntityRenderer(IafTileEntityRegistry.EGG_IN_ICE.get(), manager -> new RenderEggInIce(manager));
+        ClientRegistry.bindTileEntityRenderer(IafTileEntityRegistry.PIXIE_HOUSE.get(), manager -> new RenderPixieHouse(manager));
+        ClientRegistry.bindTileEntityRenderer(IafTileEntityRegistry.PIXIE_JAR.get(), manager -> new RenderJar(manager));
+        ClientRegistry.bindTileEntityRenderer(IafTileEntityRegistry.DREAD_PORTAL.get(), manager -> new RenderDreadPortal(manager));
+        ClientRegistry.bindTileEntityRenderer(IafTileEntityRegistry.DREAD_SPAWNER.get(), manager -> new RenderDreadSpawner(manager));
+        ClientRegistry.bindTileEntityRenderer(IafTileEntityRegistry.GHOST_CHEST.get(), manager -> new RenderGhostChest(manager));
         RenderTypeLookup.setRenderLayer(IafBlockRegistry.GOLD_PILE, RenderType.getCutout());
         RenderTypeLookup.setRenderLayer(IafBlockRegistry.SILVER_PILE, RenderType.getCutout());
         RenderTypeLookup.setRenderLayer(IafBlockRegistry.LECTERN, RenderType.getCutout());

--- a/src/main/java/com/github/alexthe666/iceandfire/IceAndFire.java
+++ b/src/main/java/com/github/alexthe666/iceandfire/IceAndFire.java
@@ -3,6 +3,7 @@ package com.github.alexthe666.iceandfire;
 
 import com.github.alexthe666.citadel.server.message.PropertiesMessage;
 import com.github.alexthe666.iceandfire.entity.IafVillagerRegistry;
+import com.github.alexthe666.iceandfire.entity.tile.IafTileEntityRegistry;
 import com.github.alexthe666.iceandfire.message.*;
 import com.github.alexthe666.iceandfire.world.IafProcessors;
 import org.apache.logging.log4j.LogManager;
@@ -82,6 +83,8 @@ public class IceAndFire {
         MinecraftForge.EVENT_BUS.addListener(this::onServerStarted);
         PROXY.init();
         IafWorldRegistry.register();
+        
+        IafTileEntityRegistry.TYPES.register(FMLJavaModLoadingContext.get().getModEventBus());
     }
 
     @SubscribeEvent

--- a/src/main/java/com/github/alexthe666/iceandfire/block/BlockGhostChest.java
+++ b/src/main/java/com/github/alexthe666/iceandfire/block/BlockGhostChest.java
@@ -19,8 +19,6 @@ import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.MathHelper;
 import net.minecraft.world.IBlockReader;
 
-import net.minecraft.block.AbstractBlock.Properties;
-
 public class BlockGhostChest extends ChestBlock implements ICustomRendered {
 
     public BlockGhostChest() {
@@ -30,29 +28,34 @@ public class BlockGhostChest extends ChestBlock implements ICustomRendered {
     			.hardnessAndResistance(2.5F)
     			.sound(SoundType.WOOD),
 			() -> {
-	            return IafTileEntityRegistry.GHOST_CHEST;
+                return IafTileEntityRegistry.GHOST_CHEST.get();
 	        }
 		);
 
         setRegistryName(IceAndFire.MODID, "ghost_chest");
     }
 
+    @Override
     public TileEntity createNewTileEntity(IBlockReader worldIn) {
         return new TileEntityGhostChest();
     }
 
+    @Override
     protected Stat<ResourceLocation> getOpenStat() {
         return Stats.CUSTOM.get(Stats.TRIGGER_TRAPPED_CHEST);
     }
 
+    @Override
     public boolean canProvidePower(BlockState state) {
         return true;
     }
 
+    @Override
     public int getWeakPower(BlockState blockState, IBlockReader blockAccess, BlockPos pos, Direction side) {
         return MathHelper.clamp(ChestTileEntity.getPlayersUsing(blockAccess, pos), 0, 15);
     }
 
+    @Override
     public int getStrongPower(BlockState blockState, IBlockReader blockAccess, BlockPos pos, Direction side) {
         return side == Direction.UP ? blockState.getWeakPower(blockAccess, pos, side) : 0;
     }

--- a/src/main/java/com/github/alexthe666/iceandfire/entity/tile/IafTileEntityRegistry.java
+++ b/src/main/java/com/github/alexthe666/iceandfire/entity/tile/IafTileEntityRegistry.java
@@ -1,52 +1,37 @@
 package com.github.alexthe666.iceandfire.entity.tile;
 
-import java.lang.reflect.Field;
-
 import com.github.alexthe666.iceandfire.IceAndFire;
 import com.github.alexthe666.iceandfire.block.IafBlockRegistry;
 
+import net.minecraft.tileentity.TileEntity;
 import net.minecraft.tileentity.TileEntityType;
-import net.minecraft.util.ResourceLocation;
-import net.minecraftforge.event.RegistryEvent;
-import net.minecraftforge.eventbus.api.SubscribeEvent;
-import net.minecraftforge.fml.common.Mod;
 
-@Mod.EventBusSubscriber(modid = IceAndFire.MODID, bus = Mod.EventBusSubscriber.Bus.MOD)
+import net.minecraftforge.fml.RegistryObject;
+import net.minecraftforge.registries.DeferredRegister;
+import net.minecraftforge.registries.ForgeRegistries;
+
 public class IafTileEntityRegistry {
-    public static final TileEntityType<TileEntityLectern> IAF_LECTERN = registerTileEntity(TileEntityType.Builder.create(TileEntityLectern::new, IafBlockRegistry.LECTERN), "iaf_lectern");
-    public static final TileEntityType<TileEntityPodium> PODIUM = registerTileEntity(TileEntityType.Builder.create(TileEntityPodium::new, IafBlockRegistry.PODIUM_OAK, IafBlockRegistry.PODIUM_BIRCH, IafBlockRegistry.PODIUM_SPRUCE, IafBlockRegistry.PODIUM_JUNGLE, IafBlockRegistry.PODIUM_DARK_OAK, IafBlockRegistry.PODIUM_ACACIA), "podium");
-    public static final TileEntityType<TileEntityEggInIce> EGG_IN_ICE = registerTileEntity(TileEntityType.Builder.create(TileEntityEggInIce::new, IafBlockRegistry.EGG_IN_ICE), "egg_in_ice");
-    public static final TileEntityType<TileEntityPixieHouse> PIXIE_HOUSE = registerTileEntity(TileEntityType.Builder.create(TileEntityPixieHouse::new, IafBlockRegistry.PIXIE_HOUSE_MUSHROOM_RED, IafBlockRegistry.PIXIE_HOUSE_MUSHROOM_BROWN, IafBlockRegistry.PIXIE_HOUSE_OAK, IafBlockRegistry.PIXIE_HOUSE_BIRCH, IafBlockRegistry.PIXIE_HOUSE_BIRCH, IafBlockRegistry.PIXIE_HOUSE_SPRUCE, IafBlockRegistry.PIXIE_HOUSE_DARK_OAK), "pixie_house");
-    public static final TileEntityType<TileEntityJar> PIXIE_JAR = registerTileEntity(TileEntityType.Builder.create(TileEntityJar::new, IafBlockRegistry.JAR_EMPTY, IafBlockRegistry.JAR_PIXIE_0, IafBlockRegistry.JAR_PIXIE_1, IafBlockRegistry.JAR_PIXIE_2, IafBlockRegistry.JAR_PIXIE_3, IafBlockRegistry.JAR_PIXIE_4), "pixie_jar");
-    public static final TileEntityType<TileEntityMyrmexCocoon> MYRMEX_COCOON = registerTileEntity(TileEntityType.Builder.create(TileEntityMyrmexCocoon::new, IafBlockRegistry.DESERT_MYRMEX_COCOON, IafBlockRegistry.JUNGLE_MYRMEX_COCOON), "myrmex_cocoon");
-    public static final TileEntityType<TileEntityDragonforge> DRAGONFORGE_CORE = registerTileEntity(TileEntityType.Builder.create(TileEntityDragonforge::new, IafBlockRegistry.DRAGONFORGE_FIRE_CORE, IafBlockRegistry.DRAGONFORGE_ICE_CORE, IafBlockRegistry.DRAGONFORGE_FIRE_CORE_DISABLED, IafBlockRegistry.DRAGONFORGE_ICE_CORE_DISABLED, IafBlockRegistry.DRAGONFORGE_LIGHTNING_CORE, IafBlockRegistry.DRAGONFORGE_LIGHTNING_CORE_DISABLED), "dragonforge_core");
-    public static final TileEntityType<TileEntityDragonforgeBrick> DRAGONFORGE_BRICK = registerTileEntity(TileEntityType.Builder.create(TileEntityDragonforgeBrick::new, IafBlockRegistry.DRAGONFORGE_FIRE_BRICK, IafBlockRegistry.DRAGONFORGE_ICE_BRICK, IafBlockRegistry.DRAGONFORGE_LIGHTNING_BRICK), "dragonforge_brick");
-    public static final TileEntityType<TileEntityDragonforgeInput> DRAGONFORGE_INPUT = registerTileEntity(TileEntityType.Builder.create(TileEntityDragonforgeInput::new, IafBlockRegistry.DRAGONFORGE_FIRE_INPUT, IafBlockRegistry.DRAGONFORGE_ICE_INPUT, IafBlockRegistry.DRAGONFORGE_LIGHTNING_INPUT), "dragonforge_input");
-    public static final TileEntityType<TileEntityDreadPortal> DREAD_PORTAL = registerTileEntity(TileEntityType.Builder.create(TileEntityDreadPortal::new, IafBlockRegistry.DREAD_PORTAL), "dread_portal");
-    public static final TileEntityType<TileEntityDreadSpawner> DREAD_SPAWNER = registerTileEntity(TileEntityType.Builder.create(TileEntityDreadSpawner::new, IafBlockRegistry.DREAD_SPAWNER), "dread_spawner");
-    public static final TileEntityType<TileEntityGhostChest> GHOST_CHEST = registerTileEntity(TileEntityType.Builder.create(TileEntityGhostChest::new, IafBlockRegistry.GHOST_CHEST), "ghost_chest");
+
+    public static final DeferredRegister<TileEntityType<?>> TYPES = DeferredRegister
+        .create(ForgeRegistries.TILE_ENTITIES, IceAndFire.MODID);
+
+    //@formatter:off
+    public static final RegistryObject<TileEntityType<TileEntityLectern>> IAF_LECTERN = registerTileEntity(TileEntityType.Builder.create(TileEntityLectern::new, IafBlockRegistry.LECTERN), "iaf_lectern");
+    public static final RegistryObject<TileEntityType<TileEntityPodium>> PODIUM = registerTileEntity(TileEntityType.Builder.create(TileEntityPodium::new, IafBlockRegistry.PODIUM_OAK, IafBlockRegistry.PODIUM_BIRCH, IafBlockRegistry.PODIUM_SPRUCE, IafBlockRegistry.PODIUM_JUNGLE, IafBlockRegistry.PODIUM_DARK_OAK, IafBlockRegistry.PODIUM_ACACIA), "podium");
+    public static final RegistryObject<TileEntityType<TileEntityEggInIce>> EGG_IN_ICE = registerTileEntity(TileEntityType.Builder.create(TileEntityEggInIce::new, IafBlockRegistry.EGG_IN_ICE), "egg_in_ice");
+    public static final RegistryObject<TileEntityType<TileEntityPixieHouse>> PIXIE_HOUSE = registerTileEntity(TileEntityType.Builder.create(TileEntityPixieHouse::new, IafBlockRegistry.PIXIE_HOUSE_MUSHROOM_RED, IafBlockRegistry.PIXIE_HOUSE_MUSHROOM_BROWN, IafBlockRegistry.PIXIE_HOUSE_OAK, IafBlockRegistry.PIXIE_HOUSE_BIRCH, IafBlockRegistry.PIXIE_HOUSE_BIRCH, IafBlockRegistry.PIXIE_HOUSE_SPRUCE, IafBlockRegistry.PIXIE_HOUSE_DARK_OAK), "pixie_house");
+    public static final RegistryObject<TileEntityType<TileEntityJar>> PIXIE_JAR = registerTileEntity(TileEntityType.Builder.create(TileEntityJar::new, IafBlockRegistry.JAR_EMPTY, IafBlockRegistry.JAR_PIXIE_0, IafBlockRegistry.JAR_PIXIE_1, IafBlockRegistry.JAR_PIXIE_2, IafBlockRegistry.JAR_PIXIE_3, IafBlockRegistry.JAR_PIXIE_4), "pixie_jar");
+    public static final RegistryObject<TileEntityType<TileEntityMyrmexCocoon>> MYRMEX_COCOON = registerTileEntity(TileEntityType.Builder.create(TileEntityMyrmexCocoon::new, IafBlockRegistry.DESERT_MYRMEX_COCOON, IafBlockRegistry.JUNGLE_MYRMEX_COCOON), "myrmex_cocoon");
+    public static final RegistryObject<TileEntityType<TileEntityDragonforge>> DRAGONFORGE_CORE = registerTileEntity(TileEntityType.Builder.create(TileEntityDragonforge::new, IafBlockRegistry.DRAGONFORGE_FIRE_CORE, IafBlockRegistry.DRAGONFORGE_ICE_CORE, IafBlockRegistry.DRAGONFORGE_FIRE_CORE_DISABLED, IafBlockRegistry.DRAGONFORGE_ICE_CORE_DISABLED, IafBlockRegistry.DRAGONFORGE_LIGHTNING_CORE, IafBlockRegistry.DRAGONFORGE_LIGHTNING_CORE_DISABLED), "dragonforge_core");
+    public static final RegistryObject<TileEntityType<TileEntityDragonforgeBrick>> DRAGONFORGE_BRICK = registerTileEntity(TileEntityType.Builder.create(TileEntityDragonforgeBrick::new, IafBlockRegistry.DRAGONFORGE_FIRE_BRICK, IafBlockRegistry.DRAGONFORGE_ICE_BRICK, IafBlockRegistry.DRAGONFORGE_LIGHTNING_BRICK), "dragonforge_brick");
+    public static final RegistryObject<TileEntityType<TileEntityDragonforgeInput>> DRAGONFORGE_INPUT = registerTileEntity(TileEntityType.Builder.create(TileEntityDragonforgeInput::new, IafBlockRegistry.DRAGONFORGE_FIRE_INPUT, IafBlockRegistry.DRAGONFORGE_ICE_INPUT, IafBlockRegistry.DRAGONFORGE_LIGHTNING_INPUT), "dragonforge_input");
+    public static final RegistryObject<TileEntityType<TileEntityDreadPortal>> DREAD_PORTAL = registerTileEntity(TileEntityType.Builder.create(TileEntityDreadPortal::new, IafBlockRegistry.DREAD_PORTAL), "dread_portal");
+    public static final RegistryObject<TileEntityType<TileEntityDreadSpawner>> DREAD_SPAWNER = registerTileEntity(TileEntityType.Builder.create(TileEntityDreadSpawner::new, IafBlockRegistry.DREAD_SPAWNER), "dread_spawner");
+    public static final RegistryObject<TileEntityType<TileEntityGhostChest>> GHOST_CHEST = registerTileEntity(TileEntityType.Builder.create(TileEntityGhostChest::new, IafBlockRegistry.GHOST_CHEST), "ghost_chest");
 
 
-    public static TileEntityType registerTileEntity(TileEntityType.Builder builder, String entityName) {
-        ResourceLocation nameLoc = new ResourceLocation(IceAndFire.MODID, entityName);
-        return (TileEntityType) builder.build(null).setRegistryName(nameLoc);
-    }
-
-    @SubscribeEvent
-    public static void registerTileEntities(final RegistryEvent.Register<TileEntityType<?>> event) {
-        try {
-            for (Field f : IafTileEntityRegistry.class.getDeclaredFields()) {
-                Object obj = f.get(null);
-                if (obj instanceof TileEntityType) {
-                    event.getRegistry().register((TileEntityType) obj);
-                } else if (obj instanceof TileEntityType[]) {
-                    for (TileEntityType te : (TileEntityType[]) obj) {
-                        event.getRegistry().register(te);
-                    }
-                }
-            }
-        } catch (IllegalAccessException e) {
-            throw new RuntimeException(e);
-        }
+    public static <T extends TileEntity> RegistryObject<TileEntityType<T>> registerTileEntity(
+        TileEntityType.Builder<T> builder, String entityName) {
+        return TYPES.register(entityName, () -> builder.build(null));
     }
 }

--- a/src/main/java/com/github/alexthe666/iceandfire/entity/tile/TileEntityDragonforge.java
+++ b/src/main/java/com/github/alexthe666/iceandfire/entity/tile/TileEntityDragonforge.java
@@ -54,18 +54,20 @@ public class TileEntityDragonforge extends LockableTileEntity implements ITickab
     private boolean canAddFlameAgain = true;
 
     public TileEntityDragonforge() {
-        super(IafTileEntityRegistry.DRAGONFORGE_CORE);
+        super(IafTileEntityRegistry.DRAGONFORGE_CORE.get());
     }
 
     public TileEntityDragonforge(int isFire) {
-        super(IafTileEntityRegistry.DRAGONFORGE_CORE);
+        super(IafTileEntityRegistry.DRAGONFORGE_CORE.get());
         this.isFire = isFire;
     }
 
+    @Override
     public int getSizeInventory() {
         return this.forgeItemStacks.size();
     }
 
+    @Override
     public boolean isEmpty() {
         for (ItemStack itemstack : this.forgeItemStacks) {
             if (!itemstack.isEmpty()) {
@@ -114,18 +116,22 @@ public class TileEntityDragonforge extends LockableTileEntity implements ITickab
         return false;
     }
 
+    @Override
     public ItemStack getStackInSlot(int index) {
         return this.forgeItemStacks.get(index);
     }
 
+    @Override
     public ItemStack decrStackSize(int index, int count) {
         return ItemStackHelper.getAndSplit(this.forgeItemStacks, index, count);
     }
 
+    @Override
     public ItemStack removeStackFromSlot(int index) {
         return ItemStackHelper.getAndRemove(this.forgeItemStacks, index);
     }
 
+    @Override
     public void setInventorySlotContents(int index, ItemStack stack) {
         ItemStack itemstack = this.forgeItemStacks.get(index);
         boolean flag = !stack.isEmpty() && stack.isItemEqual(itemstack) && ItemStack.areItemStackTagsEqual(stack, itemstack);
@@ -141,6 +147,7 @@ public class TileEntityDragonforge extends LockableTileEntity implements ITickab
         }
     }
 
+    @Override
     public void read(BlockState state, CompoundNBT compound) {
         super.read(state, compound);
         this.forgeItemStacks = NonNullList.withSize(this.getSizeInventory(), ItemStack.EMPTY);
@@ -148,6 +155,7 @@ public class TileEntityDragonforge extends LockableTileEntity implements ITickab
         this.cookTime = compound.getInt("CookTime");
     }
 
+    @Override
     public CompoundNBT write(CompoundNBT compound) {
         super.write(compound);
         compound.putInt("CookTime", (short) this.cookTime);
@@ -155,6 +163,7 @@ public class TileEntityDragonforge extends LockableTileEntity implements ITickab
         return compound;
     }
 
+    @Override
     public int getInventoryStackLimit() {
         return 64;
     }
@@ -188,6 +197,7 @@ public class TileEntityDragonforge extends LockableTileEntity implements ITickab
         return "";
     }
 
+    @Override
     public void tick() {
         boolean flag = this.isBurning();
         boolean flag1 = false;
@@ -332,11 +342,12 @@ public class TileEntityDragonforge extends LockableTileEntity implements ITickab
         );
     }
 
+    @Override
     public boolean isUsableByPlayer(PlayerEntity player) {
         if (this.world.getTileEntity(this.pos) != this) {
             return false;
         } else {
-            return player.getDistanceSq((double) this.pos.getX() + 0.5D, (double) this.pos.getY() + 0.5D, (double) this.pos.getZ() + 0.5D) <= 64.0D;
+            return player.getDistanceSq(this.pos.getX() + 0.5D, this.pos.getY() + 0.5D, this.pos.getZ() + 0.5D) <= 64.0D;
         }
     }
 
@@ -361,12 +372,15 @@ public class TileEntityDragonforge extends LockableTileEntity implements ITickab
         bloodStack.shrink(1);
     }
 
+    @Override
     public void openInventory(PlayerEntity player) {
     }
 
+    @Override
     public void closeInventory(PlayerEntity player) {
     }
 
+    @Override
     public boolean isItemValidForSlot(int index, ItemStack stack) {
         if (index == 2) {
             return false;
@@ -379,6 +393,7 @@ public class TileEntityDragonforge extends LockableTileEntity implements ITickab
         return index == 0;
     }
 
+    @Override
     public int[] getSlotsForFace(Direction side) {
         if (side == Direction.DOWN) {
             return SLOTS_BOTTOM;
@@ -387,10 +402,12 @@ public class TileEntityDragonforge extends LockableTileEntity implements ITickab
         }
     }
 
+    @Override
     public boolean canInsertItem(int index, ItemStack itemStackIn, Direction direction) {
         return this.isItemValidForSlot(index, itemStackIn);
     }
 
+    @Override
     public boolean canExtractItem(int index, ItemStack stack, Direction direction) {
         if (direction == Direction.DOWN && index == 1) {
             Item item = stack.getItem();
@@ -413,6 +430,7 @@ public class TileEntityDragonforge extends LockableTileEntity implements ITickab
         return 1;
     }
 
+    @Override
     public void clear() {
         this.forgeItemStacks.clear();
     }
@@ -486,6 +504,7 @@ public class TileEntityDragonforge extends LockableTileEntity implements ITickab
         read(this.getBlockState(), packet.getNbtCompound());
     }
 
+    @Override
     public CompoundNBT getUpdateTag() {
         return this.write(new CompoundNBT());
     }

--- a/src/main/java/com/github/alexthe666/iceandfire/entity/tile/TileEntityDragonforgeBrick.java
+++ b/src/main/java/com/github/alexthe666/iceandfire/entity/tile/TileEntityDragonforgeBrick.java
@@ -4,12 +4,13 @@ import javax.annotation.Nullable;
 
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.Direction;
+
 import net.minecraftforge.common.capabilities.ICapabilityProvider;
 
 public class TileEntityDragonforgeBrick extends TileEntity {
 
     public TileEntityDragonforgeBrick() {
-        super(IafTileEntityRegistry.DRAGONFORGE_BRICK);
+        super(IafTileEntityRegistry.DRAGONFORGE_BRICK.get());
     }
 
     @Override

--- a/src/main/java/com/github/alexthe666/iceandfire/entity/tile/TileEntityDragonforgeInput.java
+++ b/src/main/java/com/github/alexthe666/iceandfire/entity/tile/TileEntityDragonforgeInput.java
@@ -26,7 +26,7 @@ public class TileEntityDragonforgeInput extends TileEntity implements ITickableT
     private TileEntityDragonforge core = null;
 
     public TileEntityDragonforgeInput() {
-        super(IafTileEntityRegistry.DRAGONFORGE_INPUT);
+        super(IafTileEntityRegistry.DRAGONFORGE_INPUT.get());
     }
 
     public void onHitWithFlame() {
@@ -66,6 +66,7 @@ public class TileEntityDragonforgeInput extends TileEntity implements ITickableT
         read(this.getBlockState(), packet.getNbtCompound());
     }
 
+    @Override
     public CompoundNBT getUpdateTag() {
         return this.write(new CompoundNBT());
     }

--- a/src/main/java/com/github/alexthe666/iceandfire/entity/tile/TileEntityDreadPortal.java
+++ b/src/main/java/com/github/alexthe666/iceandfire/entity/tile/TileEntityDreadPortal.java
@@ -8,6 +8,7 @@ import net.minecraft.tileentity.ITickableTileEntity;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.Direction;
 import net.minecraft.util.math.BlockPos;
+
 import net.minecraftforge.api.distmarker.Dist;
 import net.minecraftforge.api.distmarker.OnlyIn;
 
@@ -17,9 +18,10 @@ public class TileEntityDreadPortal extends TileEntity implements ITickableTileEn
     private boolean exactTeleport;
 
     public TileEntityDreadPortal() {
-        super(IafTileEntityRegistry.DREAD_PORTAL);
+        super(IafTileEntityRegistry.DREAD_PORTAL.get());
     }
 
+    @Override
     public CompoundNBT write(CompoundNBT compound) {
         super.write(compound);
         compound.putLong("Age", this.age);
@@ -35,6 +37,7 @@ public class TileEntityDreadPortal extends TileEntity implements ITickableTileEn
         return compound;
     }
 
+    @Override
     public void read(BlockState state, CompoundNBT compound) {
         super.read(state, compound);
         this.age = compound.getLong("Age");
@@ -46,11 +49,13 @@ public class TileEntityDreadPortal extends TileEntity implements ITickableTileEn
         this.exactTeleport = compound.getBoolean("ExactTeleport");
     }
 
+    @Override
     @OnlyIn(Dist.CLIENT)
     public double getMaxRenderDistanceSquared() {
         return 65536.0D;
     }
 
+    @Override
     public void tick() {
         ++this.age;
     }
@@ -65,6 +70,7 @@ public class TileEntityDreadPortal extends TileEntity implements ITickableTileEn
         read(this.getBlockState(), packet.getNbtCompound());
     }
 
+    @Override
     public CompoundNBT getUpdateTag() {
         return this.write(new CompoundNBT());
     }

--- a/src/main/java/com/github/alexthe666/iceandfire/entity/tile/TileEntityDreadSpawner.java
+++ b/src/main/java/com/github/alexthe666/iceandfire/entity/tile/TileEntityDreadSpawner.java
@@ -6,7 +6,6 @@ import net.minecraft.nbt.CompoundNBT;
 import net.minecraft.network.NetworkManager;
 import net.minecraft.network.play.server.SUpdateTileEntityPacket;
 import net.minecraft.tileentity.ITickableTileEntity;
-import net.minecraft.tileentity.MobSpawnerTileEntity;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.WeightedSpawnerEntity;
 import net.minecraft.util.math.BlockPos;
@@ -15,18 +14,22 @@ import net.minecraft.world.spawner.AbstractSpawner;
 
 public class TileEntityDreadSpawner extends TileEntity implements ITickableTileEntity {
     private final DreadSpawnerBaseLogic spawnerLogic = new DreadSpawnerBaseLogic() {
+        @Override
         public void broadcastEvent(int id) {
             TileEntityDreadSpawner.this.world.addBlockEvent(TileEntityDreadSpawner.this.pos, Blocks.SPAWNER, id, 0);
         }
 
+        @Override
         public World getWorld() {
             return TileEntityDreadSpawner.this.world;
         }
 
+        @Override
         public BlockPos getSpawnerPosition() {
             return TileEntityDreadSpawner.this.pos;
         }
 
+        @Override
         public void setNextSpawnData(WeightedSpawnerEntity nextSpawnData) {
             super.setNextSpawnData(nextSpawnData);
 
@@ -38,14 +41,16 @@ public class TileEntityDreadSpawner extends TileEntity implements ITickableTileE
     };
 
     public TileEntityDreadSpawner() {
-        super(IafTileEntityRegistry.DREAD_SPAWNER);
+        super(IafTileEntityRegistry.DREAD_SPAWNER.get());
     }
 
+    @Override
     public void read(BlockState blockstate, CompoundNBT compound) {
         super.read(blockstate, compound);
         this.spawnerLogic.read(compound);
     }
 
+    @Override
     public CompoundNBT write(CompoundNBT compound) {
         super.write(compound);
         this.spawnerLogic.write(compound);
@@ -55,6 +60,7 @@ public class TileEntityDreadSpawner extends TileEntity implements ITickableTileE
     /**
      * Like the old updateEntity(), except more generic.
      */
+    @Override
     public void tick() {
         this.spawnerLogic.updateSpawner();
     }
@@ -73,15 +79,18 @@ public class TileEntityDreadSpawner extends TileEntity implements ITickableTileE
         read(this.getBlockState(), packet.getNbtCompound());
     }
 
+    @Override
     public CompoundNBT getUpdateTag() {
         return this.write(new CompoundNBT());
     }
 
 
+    @Override
     public boolean receiveClientEvent(int id, int type) {
         return this.spawnerLogic.setDelayToMin(id) || super.receiveClientEvent(id, type);
     }
 
+    @Override
     public boolean onlyOpsCanSetNbt() {
         return true;
     }

--- a/src/main/java/com/github/alexthe666/iceandfire/entity/tile/TileEntityEggInIce.java
+++ b/src/main/java/com/github/alexthe666/iceandfire/entity/tile/TileEntityEggInIce.java
@@ -30,7 +30,7 @@ public class TileEntityEggInIce extends TileEntity implements ITickableTileEntit
     public UUID ownerUUID;
 
     public TileEntityEggInIce() {
-        super(IafTileEntityRegistry.EGG_IN_ICE);
+        super(IafTileEntityRegistry.EGG_IN_ICE.get());
     }
 
     @Override
@@ -78,6 +78,7 @@ public class TileEntityEggInIce extends TileEntity implements ITickableTileEntit
         read(this.getBlockState(), packet.getNbtCompound());
     }
 
+    @Override
     public CompoundNBT getUpdateTag() {
         return this.write(new CompoundNBT());
     }

--- a/src/main/java/com/github/alexthe666/iceandfire/entity/tile/TileEntityGhostChest.java
+++ b/src/main/java/com/github/alexthe666/iceandfire/entity/tile/TileEntityGhostChest.java
@@ -16,17 +16,20 @@ import net.minecraft.world.server.ServerWorld;
 public class TileEntityGhostChest extends ChestTileEntity {
 
     public TileEntityGhostChest() {
-        super(IafTileEntityRegistry.GHOST_CHEST);
+        super(IafTileEntityRegistry.GHOST_CHEST.get());
     }
 
+    @Override
     public void read(BlockState state, CompoundNBT nbt) {
         super.read(state, nbt);
     }
 
+    @Override
     public CompoundNBT write(CompoundNBT compound) {
         super.write(compound);
         return compound;
     }
+    @Override
     public void openInventory(PlayerEntity player) {
         super.openInventory(player);
         if(this.world.getDifficulty() != Difficulty.PEACEFUL){
@@ -47,6 +50,7 @@ public class TileEntityGhostChest extends ChestTileEntity {
         }
     }
 
+    @Override
     protected void onOpenOrClose() {
         super.onOpenOrClose();
         this.world.notifyNeighborsOfStateChange(this.pos.down(), this.getBlockState().getBlock());

--- a/src/main/java/com/github/alexthe666/iceandfire/entity/tile/TileEntityJar.java
+++ b/src/main/java/com/github/alexthe666/iceandfire/entity/tile/TileEntityJar.java
@@ -45,17 +45,18 @@ public class TileEntityJar extends TileEntity implements ITickableTileEntity {
     private Random rand;
 
     public TileEntityJar() {
-        super(IafTileEntityRegistry.PIXIE_JAR);
+        super(IafTileEntityRegistry.PIXIE_JAR.get());
         this.rand = new Random();
         this.hasPixie = true;
     }
 
     public TileEntityJar(boolean empty) {
-        super(IafTileEntityRegistry.PIXIE_JAR);
+        super(IafTileEntityRegistry.PIXIE_JAR.get());
         this.rand = new Random();
         this.hasPixie = !empty;
     }
 
+    @Override
     public CompoundNBT write(CompoundNBT compound) {
         super.write(compound);
         compound.putBoolean("HasPixie", hasPixie);
@@ -83,10 +84,12 @@ public class TileEntityJar extends TileEntity implements ITickableTileEntity {
         }
     }
 
+    @Override
     public CompoundNBT getUpdateTag() {
         return this.write(new CompoundNBT());
     }
 
+    @Override
     public void read(BlockState state, CompoundNBT compound) {
         hasPixie = compound.getBoolean("HasPixie");
         pixieType = compound.getInt("PixieType");
@@ -105,7 +108,7 @@ public class TileEntityJar extends TileEntity implements ITickableTileEntity {
     public void tick() {
         ticksExisted++;
         if (this.world.isRemote && this.hasPixie) {
-            IceAndFire.PROXY.spawnParticle("if_pixie", this.pos.getX() + 0.5F + (double) (this.rand.nextFloat() * PARTICLE_WIDTH * 2F) - (double) PARTICLE_WIDTH, this.pos.getY() + (double) (this.rand.nextFloat() * PARTICLE_HEIGHT), this.pos.getZ() + 0.5F + (double) (this.rand.nextFloat() * PARTICLE_WIDTH * 2F) - (double) PARTICLE_WIDTH, EntityPixie.PARTICLE_RGB[this.pixieType][0], EntityPixie.PARTICLE_RGB[this.pixieType][1], EntityPixie.PARTICLE_RGB[this.pixieType][2]);
+            IceAndFire.PROXY.spawnParticle("if_pixie", this.pos.getX() + 0.5F + (double) (this.rand.nextFloat() * PARTICLE_WIDTH * 2F) - PARTICLE_WIDTH, this.pos.getY() + (double) (this.rand.nextFloat() * PARTICLE_HEIGHT), this.pos.getZ() + 0.5F + (double) (this.rand.nextFloat() * PARTICLE_WIDTH * 2F) - PARTICLE_WIDTH, EntityPixie.PARTICLE_RGB[this.pixieType][0], EntityPixie.PARTICLE_RGB[this.pixieType][1], EntityPixie.PARTICLE_RGB[this.pixieType][2]);
         }
         if (ticksExisted % 24000 == 0 && !this.hasProduced && this.hasPixie) {
             this.hasProduced = true;

--- a/src/main/java/com/github/alexthe666/iceandfire/entity/tile/TileEntityLectern.java
+++ b/src/main/java/com/github/alexthe666/iceandfire/entity/tile/TileEntityLectern.java
@@ -67,7 +67,7 @@ public class TileEntityLectern extends LockableTileEntity implements ITickableTi
     private NonNullList<ItemStack> stacks = NonNullList.withSize(3, ItemStack.EMPTY);
 
     public TileEntityLectern() {
-        super(IafTileEntityRegistry.IAF_LECTERN);
+        super(IafTileEntityRegistry.IAF_LECTERN.get());
     }
 
     @Override
@@ -248,6 +248,7 @@ public class TileEntityLectern extends LockableTileEntity implements ITickableTi
         this.stacks.clear();
     }
 
+    @Override
     public ITextComponent getName() {
         return new TranslationTextComponent("block.iceandfire.lectern");
     }
@@ -291,6 +292,7 @@ public class TileEntityLectern extends LockableTileEntity implements ITickableTi
         read(this.getBlockState(), packet.getNbtCompound());
     }
 
+    @Override
     public CompoundNBT getUpdateTag() {
         return this.write(new CompoundNBT());
     }

--- a/src/main/java/com/github/alexthe666/iceandfire/entity/tile/TileEntityMyrmexCocoon.java
+++ b/src/main/java/com/github/alexthe666/iceandfire/entity/tile/TileEntityMyrmexCocoon.java
@@ -26,13 +26,15 @@ public class TileEntityMyrmexCocoon extends LockableLootTileEntity {
     private NonNullList<ItemStack> chestContents = NonNullList.withSize(18, ItemStack.EMPTY);
 
     public TileEntityMyrmexCocoon() {
-        super(IafTileEntityRegistry.MYRMEX_COCOON);
+        super(IafTileEntityRegistry.MYRMEX_COCOON.get());
     }
 
+    @Override
     public int getSizeInventory() {
         return 18;
     }
 
+    @Override
     public boolean isEmpty() {
         for (ItemStack itemstack : this.chestContents) {
             if (!itemstack.isEmpty()) {
@@ -43,6 +45,7 @@ public class TileEntityMyrmexCocoon extends LockableLootTileEntity {
     }
 
 
+    @Override
     public void read(BlockState bs, CompoundNBT compound) {
         super.read(bs, compound);
         this.chestContents = NonNullList.withSize(this.getSizeInventory(), ItemStack.EMPTY);
@@ -52,6 +55,7 @@ public class TileEntityMyrmexCocoon extends LockableLootTileEntity {
         }
     }
 
+    @Override
     public CompoundNBT write(CompoundNBT compound) {
         super.write(compound);
         if (!this.checkLootAndWrite(compound)) {
@@ -78,11 +82,13 @@ public class TileEntityMyrmexCocoon extends LockableLootTileEntity {
     }
 
 
+    @Override
     public int getInventoryStackLimit() {
         return 64;
     }
 
 
+    @Override
     protected NonNullList<ItemStack> getItems() {
         return this.chestContents;
     }
@@ -92,11 +98,13 @@ public class TileEntityMyrmexCocoon extends LockableLootTileEntity {
 
     }
 
+    @Override
     public void openInventory(PlayerEntity player) {
         this.fillWithLoot(null);
         player.world.playSound(this.pos.getX(), this.pos.getY(), this.pos.getZ(), SoundEvents.ENTITY_SLIME_JUMP, SoundCategory.BLOCKS, 1, 1, false);
     }
 
+    @Override
     public void closeInventory(PlayerEntity player) {
         this.fillWithLoot(null);
         player.world.playSound(this.pos.getX(), this.pos.getY(), this.pos.getZ(), SoundEvents.ENTITY_SLIME_SQUISH, SoundCategory.BLOCKS, 1, 1, false);
@@ -112,6 +120,7 @@ public class TileEntityMyrmexCocoon extends LockableLootTileEntity {
         read(this.getBlockState(), packet.getNbtCompound());
     }
 
+    @Override
     public CompoundNBT getUpdateTag() {
         return this.write(new CompoundNBT());
     }

--- a/src/main/java/com/github/alexthe666/iceandfire/entity/tile/TileEntityPixieHouse.java
+++ b/src/main/java/com/github/alexthe666/iceandfire/entity/tile/TileEntityPixieHouse.java
@@ -36,7 +36,7 @@ public class TileEntityPixieHouse extends TileEntity implements ITickableTileEnt
     private Random rand;
 
     public TileEntityPixieHouse() {
-        super(IafTileEntityRegistry.PIXIE_HOUSE);
+        super(IafTileEntityRegistry.PIXIE_HOUSE.get());
         this.rand = new Random();
     }
 
@@ -62,6 +62,7 @@ public class TileEntityPixieHouse extends TileEntity implements ITickableTileEnt
         return 0;
     }
 
+    @Override
     public CompoundNBT write(CompoundNBT compound) {
         super.write(compound);
         compound.putInt("HouseType", houseType);
@@ -88,10 +89,12 @@ public class TileEntityPixieHouse extends TileEntity implements ITickableTileEnt
         }
     }
 
+    @Override
     public CompoundNBT getUpdateTag() {
         return this.write(new CompoundNBT());
     }
 
+    @Override
     public void read(BlockState state, CompoundNBT compound) {
         houseType = compound.getInt("HouseType");
         hasPixie = compound.getBoolean("HasPixie");
@@ -112,7 +115,7 @@ public class TileEntityPixieHouse extends TileEntity implements ITickableTileEnt
             releasePixie();
         }
         if (this.world.isRemote && this.hasPixie) {
-            IceAndFire.PROXY.spawnParticle("if_pixie", this.pos.getX() + 0.5F + (double) (this.rand.nextFloat() * PARTICLE_WIDTH * 2F) - (double) PARTICLE_WIDTH, this.pos.getY() + (double) (this.rand.nextFloat() * PARTICLE_HEIGHT), this.pos.getZ() + 0.5F + (double) (this.rand.nextFloat() * PARTICLE_WIDTH * 2F) - (double) PARTICLE_WIDTH, EntityPixie.PARTICLE_RGB[this.pixieType][0], EntityPixie.PARTICLE_RGB[this.pixieType][1], EntityPixie.PARTICLE_RGB[this.pixieType][2]);
+            IceAndFire.PROXY.spawnParticle("if_pixie", this.pos.getX() + 0.5F + (double) (this.rand.nextFloat() * PARTICLE_WIDTH * 2F) - PARTICLE_WIDTH, this.pos.getY() + (double) (this.rand.nextFloat() * PARTICLE_HEIGHT), this.pos.getZ() + 0.5F + (double) (this.rand.nextFloat() * PARTICLE_WIDTH * 2F) - PARTICLE_WIDTH, EntityPixie.PARTICLE_RGB[this.pixieType][0], EntityPixie.PARTICLE_RGB[this.pixieType][1], EntityPixie.PARTICLE_RGB[this.pixieType][2]);
         }
     }
 

--- a/src/main/java/com/github/alexthe666/iceandfire/entity/tile/TileEntityPodium.java
+++ b/src/main/java/com/github/alexthe666/iceandfire/entity/tile/TileEntityPodium.java
@@ -25,6 +25,7 @@ import net.minecraft.util.IntArray;
 import net.minecraft.util.NonNullList;
 import net.minecraft.util.text.ITextComponent;
 import net.minecraft.util.text.TranslationTextComponent;
+
 import net.minecraftforge.api.distmarker.Dist;
 import net.minecraftforge.api.distmarker.OnlyIn;
 
@@ -39,7 +40,7 @@ public class TileEntityPodium extends LockableTileEntity implements ITickableTil
     private NonNullList<ItemStack> stacks = NonNullList.withSize(1, ItemStack.EMPTY);
 
     public TileEntityPodium() {
-        super(IafTileEntityRegistry.PODIUM);
+        super(IafTileEntityRegistry.PODIUM.get());
     }
 
     @Override
@@ -48,6 +49,7 @@ public class TileEntityPodium extends LockableTileEntity implements ITickableTil
         ticksExisted++;
     }
 
+    @Override
     @OnlyIn(Dist.CLIENT)
     public net.minecraft.util.math.AxisAlignedBB getRenderBoundingBox() {
         return new net.minecraft.util.math.AxisAlignedBB(pos, pos.add(1, 3, 1));
@@ -182,6 +184,7 @@ public class TileEntityPodium extends LockableTileEntity implements ITickableTil
         read(this.getBlockState(), packet.getNbtCompound());
     }
 
+    @Override
     public CompoundNBT getUpdateTag() {
         return this.write(new CompoundNBT());
     }


### PR DESCRIPTION
This PR moves `IafTileEntityRegistry` to using `DeferredRegister` instead of static init, future-proofing ports to 1.18+.