### PR TITLE
(1.16) Optimise and clean-up tile entities

### DIFF
--- a/src/main/java/com/github/alexthe666/iceandfire/entity/tile/DreadSpawnerBaseLogic.java
+++ b/src/main/java/com/github/alexthe666/iceandfire/entity/tile/DreadSpawnerBaseLogic.java
@@ -105,14 +105,10 @@ public abstract class DreadSpawnerBaseLogic extends AbstractSpawner {
                     }
 
                     ListNBT listnbt = compoundnbt.getList("Pos", 6);
-                    int j = listnbt.size();
-                    double d0 = j >= 1 ? listnbt.getDouble(0)
-                        : blockpos.getX() + (world.rand.nextDouble() - world.rand.nextDouble()) * this.spawnRange
-                            + 0.5D;
-                    double d1 = j >= 2 ? listnbt.getDouble(1) : (double) (blockpos.getY() + world.rand.nextInt(3) - 1);
-                    double d2 = j >= 3 ? listnbt.getDouble(2)
-                        : blockpos.getZ() + (world.rand.nextDouble() - world.rand.nextDouble()) * this.spawnRange
-                            + 0.5D;
+                    final int j = listnbt.size();
+                    final double d0 = j >= 1 ? listnbt.getDouble(0) : blockpos.getX() + (world.rand.nextDouble() - world.rand.nextDouble()) * this.spawnRange + 0.5D;
+                    final double d1 = j >= 2 ? listnbt.getDouble(1) : (double) (blockpos.getY() + world.rand.nextInt(3) - 1);
+                    final double d2 = j >= 3 ? listnbt.getDouble(2) : blockpos.getZ() + (world.rand.nextDouble() - world.rand.nextDouble()) * this.spawnRange + 0.5D;
                     if (world.hasNoCollisions(optional.get().getBoundingBoxWithSizeApplied(d0, d1, d2)) && EntitySpawnPlacementRegistry.canSpawnEntity(optional.get(), (IServerWorld)world, SpawnReason.SPAWNER, new BlockPos(d0, d1, d2), world.getRandom())) {
                         ServerWorld serverworld = (ServerWorld)world;
                         Entity entity = EntityType.loadEntityAndExecute(compoundnbt, world, (p_221408_6_) -> {
@@ -124,7 +120,7 @@ public abstract class DreadSpawnerBaseLogic extends AbstractSpawner {
                             return;
                         }
 
-                        int k = world.getEntitiesWithinAABB(entity.getClass(), (new AxisAlignedBB(blockpos.getX(), blockpos.getY(), blockpos.getZ(), blockpos.getX() + 1, blockpos.getY() + 1, blockpos.getZ() + 1)).grow(this.spawnRange)).size();
+                        final int k = world.getEntitiesWithinAABB(entity.getClass(), (new AxisAlignedBB(blockpos.getX(), blockpos.getY(), blockpos.getZ(), blockpos.getX() + 1, blockpos.getY() + 1, blockpos.getZ() + 1)).grow(this.spawnRange)).size();
                         if (k >= this.maxNearbyEntities) {
                             this.resetTimer();
                             return;

--- a/src/main/java/com/github/alexthe666/iceandfire/entity/tile/DreadSpawnerBaseLogic.java
+++ b/src/main/java/com/github/alexthe666/iceandfire/entity/tile/DreadSpawnerBaseLogic.java
@@ -28,23 +28,21 @@ import net.minecraft.world.IServerWorld;
 import net.minecraft.world.World;
 import net.minecraft.world.server.ServerWorld;
 import net.minecraft.world.spawner.AbstractSpawner;
-import net.minecraftforge.api.distmarker.Dist;
-import net.minecraftforge.api.distmarker.OnlyIn;
 
 public abstract class DreadSpawnerBaseLogic extends AbstractSpawner {
 
     private final List<WeightedSpawnerEntity> potentialSpawns = Lists.newArrayList();
-    private int spawnDelay = 20;
+    private short spawnDelay = 20;
     private WeightedSpawnerEntity spawnData = new WeightedSpawnerEntity();
     private double mobRotation;
     private double prevMobRotation;
-    private int minSpawnDelay = 200;
-    private int maxSpawnDelay = 800;
-    private int spawnCount = 4;
+    private short minSpawnDelay = 200;
+    private short maxSpawnDelay = 800;
+    private short spawnCount = 4;
     private Entity cachedEntity;
-    private int maxNearbyEntities = 6;
-    private int activatingRangeFromPlayer = 16;
-    private int spawnRange = 4;
+    private short maxNearbyEntities = 6;
+    private short activatingRangeFromPlayer = 16;
+    private short spawnRange = 4;
 
     @Nullable
     private ResourceLocation getEntityId() {
@@ -63,7 +61,8 @@ public abstract class DreadSpawnerBaseLogic extends AbstractSpawner {
      */
     private boolean isActivated() {
         BlockPos blockpos = this.getSpawnerPosition();
-        return this.getWorld().isPlayerWithin((double) blockpos.getX() + 0.5D, (double) blockpos.getY() + 0.5D, (double) blockpos.getZ() + 0.5D, this.activatingRangeFromPlayer);
+        return this.getWorld().isPlayerWithin(blockpos.getX() + 0.5D, blockpos.getY() + 0.5D, blockpos.getZ() + 0.5D,
+            this.activatingRangeFromPlayer);
     }
 
     public void updateSpawner() {
@@ -74,9 +73,9 @@ public abstract class DreadSpawnerBaseLogic extends AbstractSpawner {
             BlockPos blockpos = this.getSpawnerPosition();
 
             if (this.getWorld().isRemote) {
-                double d3 = (float) blockpos.getX() + this.getWorld().rand.nextFloat();
-                double d4 = (float) blockpos.getY() + this.getWorld().rand.nextFloat();
-                double d5 = (float) blockpos.getZ() + this.getWorld().rand.nextFloat();
+                double d3 = blockpos.getX() + this.getWorld().rand.nextFloat();
+                double d4 = blockpos.getY() + this.getWorld().rand.nextFloat();
+                double d5 = blockpos.getZ() + this.getWorld().rand.nextFloat();
                 this.getWorld().addParticle(ParticleTypes.SMOKE, d3, d4, d5, 0.0D, 0.0D, 0.0D);
                 IceAndFire.PROXY.spawnParticle(EnumParticles.Dread_Torch, d3, d4, d5, 0.0D, 0.0D, 0.0D);
                 if (this.spawnDelay > 0) {
@@ -84,7 +83,7 @@ public abstract class DreadSpawnerBaseLogic extends AbstractSpawner {
                 }
 
                 this.prevMobRotation = this.mobRotation;
-                this.mobRotation = (this.mobRotation + (double) (1000.0F / ((float) this.spawnDelay + 200.0F))) % 360.0D;
+                this.mobRotation = (this.mobRotation + 1000.0F / (this.spawnDelay + 200.0F)) % 360.0D;
             } else {
                 if (this.spawnDelay == -1) {
                     this.resetTimer();
@@ -107,9 +106,13 @@ public abstract class DreadSpawnerBaseLogic extends AbstractSpawner {
 
                     ListNBT listnbt = compoundnbt.getList("Pos", 6);
                     int j = listnbt.size();
-                    double d0 = j >= 1 ? listnbt.getDouble(0) : (double) blockpos.getX() + (world.rand.nextDouble() - world.rand.nextDouble()) * (double) this.spawnRange + 0.5D;
+                    double d0 = j >= 1 ? listnbt.getDouble(0)
+                        : blockpos.getX() + (world.rand.nextDouble() - world.rand.nextDouble()) * this.spawnRange
+                            + 0.5D;
                     double d1 = j >= 2 ? listnbt.getDouble(1) : (double) (blockpos.getY() + world.rand.nextInt(3) - 1);
-                    double d2 = j >= 3 ? listnbt.getDouble(2) : (double) blockpos.getZ() + (world.rand.nextDouble() - world.rand.nextDouble()) * (double) this.spawnRange + 0.5D;
+                    double d2 = j >= 3 ? listnbt.getDouble(2)
+                        : blockpos.getZ() + (world.rand.nextDouble() - world.rand.nextDouble()) * this.spawnRange
+                            + 0.5D;
                     if (world.hasNoCollisions(optional.get().getBoundingBoxWithSizeApplied(d0, d1, d2)) && EntitySpawnPlacementRegistry.canSpawnEntity(optional.get(), (IServerWorld)world, SpawnReason.SPAWNER, new BlockPos(d0, d1, d2), world.getRandom())) {
                         ServerWorld serverworld = (ServerWorld)world;
                         Entity entity = EntityType.loadEntityAndExecute(compoundnbt, world, (p_221408_6_) -> {
@@ -135,14 +138,14 @@ public abstract class DreadSpawnerBaseLogic extends AbstractSpawner {
                             }
 
                             if (this.spawnData.getNbt().size() == 1 && this.spawnData.getNbt().contains("id", 8)){
-                                ((MobEntity) entity).onInitialSpawn(serverworld, world.getDifficultyForLocation(entity.getPosition()), SpawnReason.SPAWNER, null, null);
+                                mobentity.onInitialSpawn(serverworld,
+                                    world.getDifficultyForLocation(entity.getPosition()), SpawnReason.SPAWNER, null,
+                                    null);
                             }
-                        }
 
-                        this.func_221409_a(entity);
-                        world.playEvent(2004, blockpos, 0);
-                        if (entity instanceof MobEntity) {
-                            ((MobEntity) entity).spawnExplosionParticle();
+                            this.spawnMobs(entity);
+                            world.playEvent(2004, blockpos, 0);
+                            mobentity.spawnExplosionParticle();
                         }
 
                         flag = true;
@@ -156,10 +159,10 @@ public abstract class DreadSpawnerBaseLogic extends AbstractSpawner {
         }
     }
 
-    private void func_221409_a(Entity entityIn) {
+    private void spawnMobs(Entity entityIn) {
         if (this.getWorld().addEntity(entityIn)) {
             for (Entity entity : entityIn.getPassengers()) {
-                this.func_221409_a(entity);
+                this.spawnMobs(entity);
             }
 
         }
@@ -170,7 +173,7 @@ public abstract class DreadSpawnerBaseLogic extends AbstractSpawner {
             this.spawnDelay = this.minSpawnDelay;
         } else {
             int i = this.maxSpawnDelay - this.minSpawnDelay;
-            this.spawnDelay = this.minSpawnDelay + this.getWorld().rand.nextInt(i);
+            this.spawnDelay = (short) (this.minSpawnDelay + getWorld().rand.nextInt(i));
         }
 
         if (!this.potentialSpawns.isEmpty()) {
@@ -180,6 +183,7 @@ public abstract class DreadSpawnerBaseLogic extends AbstractSpawner {
         this.broadcastEvent(1);
     }
 
+    @Override
     public void read(CompoundNBT nbt) {
         this.spawnDelay = nbt.getShort("Delay");
         this.potentialSpawns.clear();
@@ -218,18 +222,19 @@ public abstract class DreadSpawnerBaseLogic extends AbstractSpawner {
 
     }
 
+    @Override
     public CompoundNBT write(CompoundNBT compound) {
         ResourceLocation resourcelocation = this.getEntityId();
         if (resourcelocation == null) {
             return compound;
         } else {
-            compound.putShort("Delay", (short) this.spawnDelay);
-            compound.putShort("MinSpawnDelay", (short) this.minSpawnDelay);
-            compound.putShort("MaxSpawnDelay", (short) this.maxSpawnDelay);
-            compound.putShort("SpawnCount", (short) this.spawnCount);
-            compound.putShort("MaxNearbyEntities", (short) this.maxNearbyEntities);
-            compound.putShort("RequiredPlayerRange", (short) this.activatingRangeFromPlayer);
-            compound.putShort("SpawnRange", (short) this.spawnRange);
+            compound.putShort("Delay", this.spawnDelay);
+            compound.putShort("MinSpawnDelay", this.minSpawnDelay);
+            compound.putShort("MaxSpawnDelay", this.maxSpawnDelay);
+            compound.putShort("SpawnCount", this.spawnCount);
+            compound.putShort("MaxNearbyEntities", this.maxNearbyEntities);
+            compound.putShort("RequiredPlayerRange", this.activatingRangeFromPlayer);
+            compound.putShort("SpawnRange", this.spawnRange);
             compound.put("SpawnData", this.spawnData.getNbt().copy());
             ListNBT listnbt = new ListNBT();
             if (this.potentialSpawns.isEmpty()) {
@@ -248,6 +253,7 @@ public abstract class DreadSpawnerBaseLogic extends AbstractSpawner {
     /**
      * Sets the delay to minDelay if parameter given is 1, else return false.
      */
+    @Override
     public boolean setDelayToMin(int delay) {
         if (delay == 1 && this.getWorld().isRemote) {
             this.spawnDelay = this.minSpawnDelay;
@@ -257,7 +263,7 @@ public abstract class DreadSpawnerBaseLogic extends AbstractSpawner {
         }
     }
 
-    @OnlyIn(Dist.CLIENT)
+    @Override
     public Entity getCachedEntity() {
         if (this.cachedEntity == null) {
             this.cachedEntity = EntityType.loadEntityAndExecute(this.spawnData.getNbt(), this.getWorld(), Function.identity());
@@ -268,20 +274,23 @@ public abstract class DreadSpawnerBaseLogic extends AbstractSpawner {
         return this.cachedEntity;
     }
 
+    @Override
     public void setNextSpawnData(WeightedSpawnerEntity nextSpawnData) {
         this.spawnData = nextSpawnData;
     }
 
+    @Override
     public abstract void broadcastEvent(int id);
 
+    @Override
     public abstract BlockPos getSpawnerPosition();
 
-    @OnlyIn(Dist.CLIENT)
+    @Override
     public double getMobRotation() {
         return this.mobRotation;
     }
 
-    @OnlyIn(Dist.CLIENT)
+    @Override
     public double getPrevMobRotation() {
         return this.prevMobRotation;
     }

--- a/src/main/java/com/github/alexthe666/iceandfire/entity/tile/PixieJarInvWrapper.java
+++ b/src/main/java/com/github/alexthe666/iceandfire/entity/tile/PixieJarInvWrapper.java
@@ -5,7 +5,7 @@ import javax.annotation.Nonnull;
 import com.github.alexthe666.iceandfire.item.IafItemRegistry;
 
 import net.minecraft.item.ItemStack;
-import net.minecraft.util.Direction;
+
 import net.minecraftforge.common.util.LazyOptional;
 import net.minecraftforge.items.IItemHandler;
 import net.minecraftforge.items.IItemHandlerModifiable;
@@ -13,15 +13,13 @@ import net.minecraftforge.items.IItemHandlerModifiable;
 public class PixieJarInvWrapper implements IItemHandlerModifiable {
 
     private TileEntityJar tile;
-    private Direction side;
 
-    public PixieJarInvWrapper(TileEntityJar tile, Direction side) {
+    public PixieJarInvWrapper(TileEntityJar tile) {
         this.tile = tile;
-        this.side = side;
     }
 
-    public static LazyOptional<IItemHandler> create(TileEntityJar trashCan, Direction sides) {
-        return LazyOptional.of(() -> new PixieJarInvWrapper(trashCan, sides));
+    public static LazyOptional<IItemHandler> create(TileEntityJar trashCan) {
+        return LazyOptional.of(() -> new PixieJarInvWrapper(trashCan));
     }
 
     @Override

--- a/src/main/java/com/github/alexthe666/iceandfire/entity/tile/TileEntityDragonforge.java
+++ b/src/main/java/com/github/alexthe666/iceandfire/entity/tile/TileEntityDragonforge.java
@@ -37,17 +37,29 @@ import net.minecraft.util.text.ITextComponent;
 import net.minecraft.util.text.TranslationTextComponent;
 
 public class TileEntityDragonforge extends LockableTileEntity implements ITickableTileEntity, ISidedInventory {
-    private static final int[] SLOTS_TOP = new int[]{0, 1};
-    private static final int[] SLOTS_BOTTOM = new int[]{2};
-    private static final int[] SLOTS_SIDES = new int[]{0, 1};
-    private static final Direction[] HORIZONTALS = new Direction[]{Direction.NORTH, Direction.EAST, Direction.SOUTH, Direction.WEST};
+
+    private static final int[] SLOTS_TOP = new int[] {
+        0, 1
+    };
+    private static final int[] SLOTS_BOTTOM = new int[] {
+        2
+    };
+    private static final int[] SLOTS_SIDES = new int[] {
+        0, 1
+    };
+    private static final Direction[] HORIZONTALS = new Direction[] {
+        Direction.NORTH, Direction.EAST, Direction.SOUTH, Direction.WEST
+    };
     public int isFire;
     public int cookTime;
-    net.minecraftforge.items.IItemHandler handlerTop = new net.minecraftforge.items.wrapper.SidedInvWrapper(this, net.minecraft.util.Direction.UP);
-    net.minecraftforge.items.IItemHandler handlerBottom = new net.minecraftforge.items.wrapper.SidedInvWrapper(this, net.minecraft.util.Direction.DOWN);
-    net.minecraftforge.items.IItemHandler handlerSide = new net.minecraftforge.items.wrapper.SidedInvWrapper(this, net.minecraft.util.Direction.WEST);
-    net.minecraftforge.common.util.LazyOptional<? extends net.minecraftforge.items.IItemHandler>[] handlers =
-            net.minecraftforge.items.wrapper.SidedInvWrapper.create(this, Direction.UP, Direction.DOWN, Direction.NORTH);
+    net.minecraftforge.items.IItemHandler handlerTop = new net.minecraftforge.items.wrapper.SidedInvWrapper(this,
+        net.minecraft.util.Direction.UP);
+    net.minecraftforge.items.IItemHandler handlerBottom = new net.minecraftforge.items.wrapper.SidedInvWrapper(this,
+        net.minecraft.util.Direction.DOWN);
+    net.minecraftforge.items.IItemHandler handlerSide = new net.minecraftforge.items.wrapper.SidedInvWrapper(this,
+        net.minecraft.util.Direction.WEST);
+    net.minecraftforge.common.util.LazyOptional<? extends net.minecraftforge.items.IItemHandler>[] handlers = net.minecraftforge.items.wrapper.SidedInvWrapper
+        .create(this, Direction.UP, Direction.DOWN, Direction.NORTH);
     private NonNullList<ItemStack> forgeItemStacks = NonNullList.withSize(3, ItemStack.EMPTY);
     public int lastDragonFlameTimer = 0;
     private boolean prevAssembled;
@@ -70,9 +82,7 @@ public class TileEntityDragonforge extends LockableTileEntity implements ITickab
     @Override
     public boolean isEmpty() {
         for (ItemStack itemstack : this.forgeItemStacks) {
-            if (!itemstack.isEmpty()) {
-                return false;
-            }
+            if (!itemstack.isEmpty()) { return false; }
         }
 
         return true;
@@ -90,30 +100,24 @@ public class TileEntityDragonforge extends LockableTileEntity implements ITickab
         }
     }
 
-    public Block getGrillBlock(){
-        if(isFire == 0){
-            return IafBlockRegistry.DRAGONFORGE_FIRE_BRICK;
-        }
-        if(isFire == 1){
-            return IafBlockRegistry.DRAGONFORGE_ICE_BRICK;
-        }
-        if(isFire == 2){
-            return IafBlockRegistry.DRAGONFORGE_LIGHTNING_BRICK;
-        }
+    public Block getGrillBlock() {
+        if (isFire == 0) { return IafBlockRegistry.DRAGONFORGE_FIRE_BRICK; }
+        if (isFire == 1) { return IafBlockRegistry.DRAGONFORGE_ICE_BRICK; }
+        if (isFire == 2) { return IafBlockRegistry.DRAGONFORGE_LIGHTNING_BRICK; }
         return IafBlockRegistry.DRAGONFORGE_FIRE_BRICK;
     }
 
-    public boolean grillMatches(Block block){
-        if(isFire == 0 && block == IafBlockRegistry.DRAGONFORGE_FIRE_BRICK){
-            return true;
+    public boolean grillMatches(Block block) {
+        switch (isFire) {
+        case 0:
+            return block == IafBlockRegistry.DRAGONFORGE_FIRE_BRICK;
+        case 1:
+            return block == IafBlockRegistry.DRAGONFORGE_ICE_BRICK;
+        case 2:
+            return block == IafBlockRegistry.DRAGONFORGE_LIGHTNING_BRICK;
+        default:
+            return false;
         }
-        if(isFire == 1 && block == IafBlockRegistry.DRAGONFORGE_ICE_BRICK){
-            return true;
-        }
-        if(isFire == 2 && block == IafBlockRegistry.DRAGONFORGE_LIGHTNING_BRICK){
-            return true;
-        }
-        return false;
     }
 
     @Override
@@ -134,14 +138,16 @@ public class TileEntityDragonforge extends LockableTileEntity implements ITickab
     @Override
     public void setInventorySlotContents(int index, ItemStack stack) {
         ItemStack itemstack = this.forgeItemStacks.get(index);
-        boolean flag = !stack.isEmpty() && stack.isItemEqual(itemstack) && ItemStack.areItemStackTagsEqual(stack, itemstack);
+        boolean flag = !stack.isEmpty() && stack.isItemEqual(itemstack)
+            && ItemStack.areItemStackTagsEqual(stack, itemstack);
         this.forgeItemStacks.set(index, stack);
 
         if (stack.getCount() > this.getInventoryStackLimit()) {
             stack.setCount(this.getInventoryStackLimit());
         }
 
-        if (index == 0 && !flag || this.cookTime > this.getMaxCookTime(forgeItemStacks.get(0), forgeItemStacks.get(1))) {
+        if (index == 0 && !flag
+            || this.cookTime > this.getMaxCookTime(forgeItemStacks.get(0), forgeItemStacks.get(1))) {
             this.cookTime = 0;
             this.markDirty();
         }
@@ -172,29 +178,32 @@ public class TileEntityDragonforge extends LockableTileEntity implements ITickab
         return this.cookTime > 0;
     }
 
-    public int getFireType(Block block){
-        if(block == IafBlockRegistry.DRAGONFORGE_FIRE_CORE || block == IafBlockRegistry.DRAGONFORGE_FIRE_CORE_DISABLED){
+    public int getFireType(Block block) {
+        if (block == IafBlockRegistry.DRAGONFORGE_FIRE_CORE
+            || block == IafBlockRegistry.DRAGONFORGE_FIRE_CORE_DISABLED) {
             return 0;
         }
-        if(block == IafBlockRegistry.DRAGONFORGE_ICE_CORE || block == IafBlockRegistry.DRAGONFORGE_ICE_CORE_DISABLED){
+        if (block == IafBlockRegistry.DRAGONFORGE_ICE_CORE || block == IafBlockRegistry.DRAGONFORGE_ICE_CORE_DISABLED) {
             return 1;
         }
-        if(block == IafBlockRegistry.DRAGONFORGE_LIGHTNING_CORE || block == IafBlockRegistry.DRAGONFORGE_LIGHTNING_CORE_DISABLED){
+        if (block == IafBlockRegistry.DRAGONFORGE_LIGHTNING_CORE
+            || block == IafBlockRegistry.DRAGONFORGE_LIGHTNING_CORE_DISABLED) {
             return 2;
         }
         return 0;
     }
 
-    public String getTypeID(){
-        switch (getFireType(this.getBlockState().getBlock())){
-            case 0:
-                return "fire";
-            case 1:
-                return "ice";
-            case 2:
-                return "lightning";
+    public String getTypeID() {
+        switch (getFireType(this.getBlockState().getBlock())) {
+        case 0:
+            return "fire";
+        case 1:
+            return "ice";
+        case 2:
+            return "lightning";
+        default:
+            return "";
         }
-        return "";
     }
 
     @Override
@@ -211,14 +220,13 @@ public class TileEntityDragonforge extends LockableTileEntity implements ITickab
                 BlockDragonforgeCore.setState(isFire, prevAssembled, world, pos);
             }
             prevAssembled = this.assembled();
-            if (!assembled()) {
+            if (!assembled())
                 return;
-            }
         }
         if (cookTime > 0 && this.canSmelt() && lastDragonFlameTimer == 0) {
             this.cookTime--;
         }
-        if(this.getStackInSlot(0).isEmpty() && !world.isRemote){
+        if (this.getStackInSlot(0).isEmpty() && !world.isRemote) {
             this.cookTime = 0;
         }
         if (!this.world.isRemote) {
@@ -231,13 +239,14 @@ public class TileEntityDragonforge extends LockableTileEntity implements ITickab
                         flag1 = true;
                     }
                 } else {
-                    if(cookTime > 0){
+                    if (cookTime > 0) {
                         IceAndFire.sendMSGToAll(new MessageUpdateDragonforge(pos.toLong(), cookTime));
                         this.cookTime = 0;
                     }
                 }
             } else if (!this.isBurning() && this.cookTime > 0) {
-                this.cookTime = MathHelper.clamp(this.cookTime - 2, 0, getMaxCookTime(forgeItemStacks.get(0), forgeItemStacks.get(1)));
+                this.cookTime = MathHelper.clamp(this.cookTime - 2, 0,
+                    getMaxCookTime(forgeItemStacks.get(0), forgeItemStacks.get(1)));
             }
 
             if (flag != this.isBurning()) {
@@ -255,7 +264,8 @@ public class TileEntityDragonforge extends LockableTileEntity implements ITickab
 
     public int getMaxCookTime(ItemStack cookStack, ItemStack bloodStack) {
         ItemStack stack = getCurrentResult(cookStack, bloodStack);
-        if (stack.getItem() == Item.getItemFromBlock(IafBlockRegistry.ASH) || stack.getItem() == Item.getItemFromBlock(IafBlockRegistry.DRAGON_ICE)) {
+        if (stack.getItem() == IafBlockRegistry.ASH.asItem()
+            || stack.getItem() == IafBlockRegistry.DRAGON_ICE.asItem()) {
             return 100;
         }
         return 1000;
@@ -263,50 +273,45 @@ public class TileEntityDragonforge extends LockableTileEntity implements ITickab
 
     private DragonForgeRecipe getRecipeForInput(ItemStack cookStack) {
         switch (this.isFire) {
-            case 0: return IafRecipeRegistry.getFireForgeRecipe(cookStack);
-            case 1: return IafRecipeRegistry.getIceForgeRecipe(cookStack);
-            case 2: return IafRecipeRegistry.getLightningForgeRecipe(cookStack);
+        case 0:
+            return IafRecipeRegistry.getFireForgeRecipe(cookStack);
+        case 1:
+            return IafRecipeRegistry.getIceForgeRecipe(cookStack);
+        case 2:
+            return IafRecipeRegistry.getLightningForgeRecipe(cookStack);
+        default:
+            return null;
         }
-
-        return null;
     }
 
     private DragonForgeRecipe getRecipeForBlood(ItemStack bloodStack) {
         switch (this.isFire) {
-            case 0: return IafRecipeRegistry.getFireForgeRecipeForBlood(bloodStack);
-            case 1: return IafRecipeRegistry.getIceForgeRecipeForBlood(bloodStack);
-            case 2: return IafRecipeRegistry.getLightningForgeRecipeForBlood(bloodStack);
+        case 0:
+            return IafRecipeRegistry.getFireForgeRecipeForBlood(bloodStack);
+        case 1:
+            return IafRecipeRegistry.getIceForgeRecipeForBlood(bloodStack);
+        case 2:
+            return IafRecipeRegistry.getLightningForgeRecipeForBlood(bloodStack);
+        default:
+            return null;
         }
-
-        return null;
     }
 
     private Block getDefaultOutput() {
-        if (this.isFire == 1) {
-            return IafBlockRegistry.DRAGON_ICE;
-        }
-
-        return IafBlockRegistry.ASH;
+        return isFire == 1 ? IafBlockRegistry.DRAGON_ICE : IafBlockRegistry.ASH;
     }
 
     private DragonForgeRecipe getCurrentRecipe(ItemStack cookStack, ItemStack bloodStack) {
         DragonForgeRecipe forgeRecipe = getRecipeForInput(cookStack);
-        if (
-            forgeRecipe != null &&
-            // Item input and quantity match
-                    forgeRecipe.getInput().test(cookStack) && cookStack.getCount() > 0 &&
+        if (forgeRecipe != null &&
+        // Item input and quantity match
+            forgeRecipe.getInput().test(cookStack) && cookStack.getCount() > 0 &&
             // Blood item and quantity match
-                    forgeRecipe.getBlood().test(bloodStack) && bloodStack.getCount() > 0
-        ) {
+            forgeRecipe.getBlood().test(bloodStack) && bloodStack.getCount() > 0)
             return forgeRecipe;
-        }
 
-        return new DragonForgeRecipe(
-            Ingredient.fromStacks(cookStack),
-                Ingredient.fromStacks(bloodStack),
-            new ItemStack(getDefaultOutput()),
-                getTypeID()
-        );
+        return new DragonForgeRecipe(Ingredient.fromStacks(cookStack), Ingredient.fromStacks(bloodStack),
+            new ItemStack(getDefaultOutput()), getTypeID());
     }
 
     private ItemStack getCurrentResult(ItemStack cookStack, ItemStack bloodStack) {
@@ -315,31 +320,23 @@ public class TileEntityDragonforge extends LockableTileEntity implements ITickab
 
     public boolean canSmelt() {
         ItemStack cookStack = this.forgeItemStacks.get(0);
-        if (cookStack.isEmpty()) {
+        if (cookStack.isEmpty())
             return false;
-        }
 
         ItemStack bloodStack = this.forgeItemStacks.get(1);
         DragonForgeRecipe forgeRecipe = getCurrentRecipe(cookStack, bloodStack);
         ItemStack forgeRecipeOutput = forgeRecipe.getOutput();
 
-        if (forgeRecipeOutput.isEmpty()) {
+        if (forgeRecipeOutput.isEmpty())
             return false;
-        }
 
         ItemStack outputStack = this.forgeItemStacks.get(2);
-        if (
-            !outputStack.isEmpty() &&
-            !outputStack.isItemEqual(forgeRecipeOutput)
-        ) {
+        if (!outputStack.isEmpty() && !outputStack.isItemEqual(forgeRecipeOutput))
             return false;
-        }
 
         int calculatedOutputCount = outputStack.getCount() + forgeRecipeOutput.getCount();
-        return (
-            calculatedOutputCount <= this.getInventoryStackLimit() &&
-            calculatedOutputCount <= outputStack.getMaxStackSize()
-        );
+        return (calculatedOutputCount <= this.getInventoryStackLimit()
+            && calculatedOutputCount <= outputStack.getMaxStackSize());
     }
 
     @Override
@@ -347,14 +344,14 @@ public class TileEntityDragonforge extends LockableTileEntity implements ITickab
         if (this.world.getTileEntity(this.pos) != this) {
             return false;
         } else {
-            return player.getDistanceSq(this.pos.getX() + 0.5D, this.pos.getY() + 0.5D, this.pos.getZ() + 0.5D) <= 64.0D;
+            return player.getDistanceSq(this.pos.getX() + 0.5D, this.pos.getY() + 0.5D,
+                this.pos.getZ() + 0.5D) <= 64.0D;
         }
     }
 
     public void smeltItem() {
-        if (!this.canSmelt()) {
+        if (!this.canSmelt())
             return;
-        }
 
         ItemStack cookStack = this.forgeItemStacks.get(0);
         ItemStack bloodStack = this.forgeItemStacks.get(1);
@@ -382,15 +379,14 @@ public class TileEntityDragonforge extends LockableTileEntity implements ITickab
 
     @Override
     public boolean isItemValidForSlot(int index, ItemStack stack) {
-        if (index == 2) {
+        switch (index) {
+        case 1:
+            return getRecipeForBlood(stack) != null;
+        case 0:
+            return true;
+        default:
             return false;
         }
-
-        if (index == 1) {
-            return getRecipeForBlood(stack) != null;
-        }
-
-        return index == 0;
     }
 
     @Override
@@ -436,8 +432,10 @@ public class TileEntityDragonforge extends LockableTileEntity implements ITickab
     }
 
     @Override
-    public <T> net.minecraftforge.common.util.LazyOptional<T> getCapability(net.minecraftforge.common.capabilities.Capability<T> capability, @Nullable Direction facing) {
-        if (!this.removed && facing != null && capability == net.minecraftforge.items.CapabilityItemHandler.ITEM_HANDLER_CAPABILITY) {
+    public <T> net.minecraftforge.common.util.LazyOptional<T> getCapability(
+        net.minecraftforge.common.capabilities.Capability<T> capability, @Nullable Direction facing) {
+        if (!this.removed && facing != null
+            && capability == net.minecraftforge.items.CapabilityItemHandler.ITEM_HANDLER_CAPABILITY) {
             if (facing == Direction.UP)
                 return handlers[0].cast();
             if (facing == Direction.DOWN)
@@ -454,10 +452,11 @@ public class TileEntityDragonforge extends LockableTileEntity implements ITickab
     }
 
     public void transferPower(int i) {
-        if(!world.isRemote){
+        if (!world.isRemote) {
             if (this.canSmelt()) {
                 if (canAddFlameAgain) {
-                    cookTime = Math.min(this.getMaxCookTime(forgeItemStacks.get(0), forgeItemStacks.get(1)) + 1, cookTime + i);
+                    cookTime = Math.min(this.getMaxCookTime(forgeItemStacks.get(0), forgeItemStacks.get(1)) + 1,
+                        cookTime + i);
                     canAddFlameAgain = false;
                 }
             } else {
@@ -469,29 +468,24 @@ public class TileEntityDragonforge extends LockableTileEntity implements ITickab
     }
 
     private boolean checkBoneCorners(BlockPos pos) {
-        return doesBlockEqual(pos.north().east(), IafBlockRegistry.DRAGON_BONE_BLOCK) &&
-                doesBlockEqual(pos.north().west(), IafBlockRegistry.DRAGON_BONE_BLOCK) &&
-                doesBlockEqual(pos.south().east(), IafBlockRegistry.DRAGON_BONE_BLOCK) &&
-                doesBlockEqual(pos.south().west(), IafBlockRegistry.DRAGON_BONE_BLOCK);
+        return doesBlockEqual(pos.north().east(), IafBlockRegistry.DRAGON_BONE_BLOCK)
+            && doesBlockEqual(pos.north().west(), IafBlockRegistry.DRAGON_BONE_BLOCK)
+            && doesBlockEqual(pos.south().east(), IafBlockRegistry.DRAGON_BONE_BLOCK)
+            && doesBlockEqual(pos.south().west(), IafBlockRegistry.DRAGON_BONE_BLOCK);
     }
 
     private boolean checkBrickCorners(BlockPos pos) {
-        return doesBlockEqual(pos.north().east(), getBrick()) &&
-                doesBlockEqual(pos.north().west(), getBrick()) &&
-                doesBlockEqual(pos.south().east(), getBrick()) &&
-                doesBlockEqual(pos.south().west(), getBrick());
+        return doesBlockEqual(pos.north().east(), getBrick()) && doesBlockEqual(pos.north().west(), getBrick())
+            && doesBlockEqual(pos.south().east(), getBrick()) && doesBlockEqual(pos.south().west(), getBrick());
     }
 
     private boolean checkBrickSlots(BlockPos pos) {
-        return doesBlockEqual(pos.north(), getBrick()) &&
-                doesBlockEqual(pos.east(), getBrick()) &&
-                doesBlockEqual(pos.west(), getBrick()) &&
-                doesBlockEqual(pos.south(), getBrick());
+        return doesBlockEqual(pos.north(), getBrick()) && doesBlockEqual(pos.east(), getBrick())
+            && doesBlockEqual(pos.west(), getBrick()) && doesBlockEqual(pos.south(), getBrick());
     }
 
     private boolean checkY(BlockPos pos) {
-        return doesBlockEqual(pos.up(), getBrick()) &&
-                doesBlockEqual(pos.down(), getBrick());
+        return doesBlockEqual(pos.up(), getBrick()) && doesBlockEqual(pos.down(), getBrick());
     }
 
     @Override
@@ -510,19 +504,19 @@ public class TileEntityDragonforge extends LockableTileEntity implements ITickab
     }
 
     public boolean assembled() {
-        return checkBoneCorners(pos.down()) && checkBrickSlots(pos.down()) &&
-                checkBrickCorners(pos) && atleastThreeAreBricks(pos) && checkY(pos) &&
-                checkBoneCorners(pos.up()) && checkBrickSlots(pos.up());
+        return checkBoneCorners(pos.down()) && checkBrickSlots(pos.down()) && checkBrickCorners(pos)
+            && atleastThreeAreBricks(pos) && checkY(pos) && checkBoneCorners(pos.up()) && checkBrickSlots(pos.up());
     }
 
     private Block getBrick() {
-        if(isFire == 0){
+        switch (isFire) {
+        case 0:
             return IafBlockRegistry.DRAGONFORGE_FIRE_BRICK;
-        }
-        if(isFire == 1){
+        case 1:
             return IafBlockRegistry.DRAGONFORGE_ICE_BRICK;
+        default:
+            return IafBlockRegistry.DRAGONFORGE_LIGHTNING_BRICK;
         }
-        return IafBlockRegistry.DRAGONFORGE_LIGHTNING_BRICK;
     }
 
     private boolean doesBlockEqual(BlockPos pos, Block block) {

--- a/src/main/java/com/github/alexthe666/iceandfire/entity/tile/TileEntityDragonforge.java
+++ b/src/main/java/com/github/alexthe666/iceandfire/entity/tile/TileEntityDragonforge.java
@@ -35,30 +35,23 @@ import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.MathHelper;
 import net.minecraft.util.text.ITextComponent;
 import net.minecraft.util.text.TranslationTextComponent;
+import net.minecraftforge.items.IItemHandler;
+import net.minecraftforge.items.wrapper.SidedInvWrapper;
 
 public class TileEntityDragonforge extends LockableTileEntity implements ITickableTileEntity, ISidedInventory {
 
-    private static final int[] SLOTS_TOP = new int[] {
-        0, 1
-    };
-    private static final int[] SLOTS_BOTTOM = new int[] {
-        2
-    };
-    private static final int[] SLOTS_SIDES = new int[] {
-        0, 1
-    };
+    private static final int[] SLOTS_TOP = new int[]{0, 1};
+    private static final int[] SLOTS_BOTTOM = new int[]{2};
+    private static final int[] SLOTS_SIDES = new int[]{0,1};
     private static final Direction[] HORIZONTALS = new Direction[] {
         Direction.NORTH, Direction.EAST, Direction.SOUTH, Direction.WEST
     };
     public int isFire;
     public int cookTime;
-    net.minecraftforge.items.IItemHandler handlerTop = new net.minecraftforge.items.wrapper.SidedInvWrapper(this,
-        net.minecraft.util.Direction.UP);
-    net.minecraftforge.items.IItemHandler handlerBottom = new net.minecraftforge.items.wrapper.SidedInvWrapper(this,
-        net.minecraft.util.Direction.DOWN);
-    net.minecraftforge.items.IItemHandler handlerSide = new net.minecraftforge.items.wrapper.SidedInvWrapper(this,
-        net.minecraft.util.Direction.WEST);
-    net.minecraftforge.common.util.LazyOptional<? extends net.minecraftforge.items.IItemHandler>[] handlers = net.minecraftforge.items.wrapper.SidedInvWrapper
+    IItemHandler handlerTop = new SidedInvWrapper(this, net.minecraft.util.Direction.UP);
+    IItemHandler handlerBottom = new SidedInvWrapper(this, net.minecraft.util.Direction.DOWN);
+    IItemHandler handlerSide = new SidedInvWrapper(this, net.minecraft.util.Direction.WEST);
+    net.minecraftforge.common.util.LazyOptional<? extends IItemHandler>[] handlers = SidedInvWrapper
         .create(this, Direction.UP, Direction.DOWN, Direction.NORTH);
     private NonNullList<ItemStack> forgeItemStacks = NonNullList.withSize(3, ItemStack.EMPTY);
     public int lastDragonFlameTimer = 0;
@@ -82,7 +75,8 @@ public class TileEntityDragonforge extends LockableTileEntity implements ITickab
     @Override
     public boolean isEmpty() {
         for (ItemStack itemstack : this.forgeItemStacks) {
-            if (!itemstack.isEmpty()) { return false; }
+            if (!itemstack.isEmpty())
+                return false;
         }
 
         return true;
@@ -101,22 +95,19 @@ public class TileEntityDragonforge extends LockableTileEntity implements ITickab
     }
 
     public Block getGrillBlock() {
-        if (isFire == 0) { return IafBlockRegistry.DRAGONFORGE_FIRE_BRICK; }
-        if (isFire == 1) { return IafBlockRegistry.DRAGONFORGE_ICE_BRICK; }
-        if (isFire == 2) { return IafBlockRegistry.DRAGONFORGE_LIGHTNING_BRICK; }
-        return IafBlockRegistry.DRAGONFORGE_FIRE_BRICK;
+        switch (isFire) {
+            case 1: return IafBlockRegistry.DRAGONFORGE_ICE_BRICK;
+            case 2: return IafBlockRegistry.DRAGONFORGE_LIGHTNING_BRICK;
+            default: return IafBlockRegistry.DRAGONFORGE_FIRE_BRICK; // isFire == 0
+        }
     }
 
     public boolean grillMatches(Block block) {
         switch (isFire) {
-        case 0:
-            return block == IafBlockRegistry.DRAGONFORGE_FIRE_BRICK;
-        case 1:
-            return block == IafBlockRegistry.DRAGONFORGE_ICE_BRICK;
-        case 2:
-            return block == IafBlockRegistry.DRAGONFORGE_LIGHTNING_BRICK;
-        default:
-            return false;
+            case 0: return block == IafBlockRegistry.DRAGONFORGE_FIRE_BRICK;
+            case 1: return block == IafBlockRegistry.DRAGONFORGE_ICE_BRICK;
+            case 2: return block == IafBlockRegistry.DRAGONFORGE_LIGHTNING_BRICK;
+            default: return false;
         }
     }
 
@@ -195,14 +186,10 @@ public class TileEntityDragonforge extends LockableTileEntity implements ITickab
 
     public String getTypeID() {
         switch (getFireType(this.getBlockState().getBlock())) {
-        case 0:
-            return "fire";
-        case 1:
-            return "ice";
-        case 2:
-            return "lightning";
-        default:
-            return "";
+            case 0: return "fire";
+            case 1: return "ice";
+            case 2: return "lightning";
+            default: return "";
         }
     }
 
@@ -273,27 +260,19 @@ public class TileEntityDragonforge extends LockableTileEntity implements ITickab
 
     private DragonForgeRecipe getRecipeForInput(ItemStack cookStack) {
         switch (this.isFire) {
-        case 0:
-            return IafRecipeRegistry.getFireForgeRecipe(cookStack);
-        case 1:
-            return IafRecipeRegistry.getIceForgeRecipe(cookStack);
-        case 2:
-            return IafRecipeRegistry.getLightningForgeRecipe(cookStack);
-        default:
-            return null;
+            case 0: return IafRecipeRegistry.getFireForgeRecipe(cookStack);
+            case 1: return IafRecipeRegistry.getIceForgeRecipe(cookStack);
+            case 2: return IafRecipeRegistry.getLightningForgeRecipe(cookStack);
+            default: return null;
         }
     }
 
     private DragonForgeRecipe getRecipeForBlood(ItemStack bloodStack) {
         switch (this.isFire) {
-        case 0:
-            return IafRecipeRegistry.getFireForgeRecipeForBlood(bloodStack);
-        case 1:
-            return IafRecipeRegistry.getIceForgeRecipeForBlood(bloodStack);
-        case 2:
-            return IafRecipeRegistry.getLightningForgeRecipeForBlood(bloodStack);
-        default:
-            return null;
+            case 0: return IafRecipeRegistry.getFireForgeRecipeForBlood(bloodStack);
+            case 1: return IafRecipeRegistry.getIceForgeRecipeForBlood(bloodStack);
+            case 2: return IafRecipeRegistry.getLightningForgeRecipeForBlood(bloodStack);
+            default: return null;
         }
     }
 
@@ -307,11 +286,16 @@ public class TileEntityDragonforge extends LockableTileEntity implements ITickab
         // Item input and quantity match
             forgeRecipe.getInput().test(cookStack) && cookStack.getCount() > 0 &&
             // Blood item and quantity match
-            forgeRecipe.getBlood().test(bloodStack) && bloodStack.getCount() > 0)
+            forgeRecipe.getBlood().test(bloodStack) && bloodStack.getCount() > 0) {
             return forgeRecipe;
+        }
 
-        return new DragonForgeRecipe(Ingredient.fromStacks(cookStack), Ingredient.fromStacks(bloodStack),
-            new ItemStack(getDefaultOutput()), getTypeID());
+        return new DragonForgeRecipe(
+                Ingredient.fromStacks(cookStack),
+                Ingredient.fromStacks(bloodStack),
+                new ItemStack(getDefaultOutput()),
+                getTypeID()
+        );
     }
 
     private ItemStack getCurrentResult(ItemStack cookStack, ItemStack bloodStack) {
@@ -380,12 +364,9 @@ public class TileEntityDragonforge extends LockableTileEntity implements ITickab
     @Override
     public boolean isItemValidForSlot(int index, ItemStack stack) {
         switch (index) {
-        case 1:
-            return getRecipeForBlood(stack) != null;
-        case 0:
-            return true;
-        default:
-            return false;
+            case 1: return getRecipeForBlood(stack) != null;
+            case 0: return true;
+            default: return false;
         }
     }
 
@@ -510,12 +491,9 @@ public class TileEntityDragonforge extends LockableTileEntity implements ITickab
 
     private Block getBrick() {
         switch (isFire) {
-        case 0:
-            return IafBlockRegistry.DRAGONFORGE_FIRE_BRICK;
-        case 1:
-            return IafBlockRegistry.DRAGONFORGE_ICE_BRICK;
-        default:
-            return IafBlockRegistry.DRAGONFORGE_LIGHTNING_BRICK;
+            case 0: return IafBlockRegistry.DRAGONFORGE_FIRE_BRICK;
+            case 1: return IafBlockRegistry.DRAGONFORGE_ICE_BRICK;
+            default: return IafBlockRegistry.DRAGONFORGE_LIGHTNING_BRICK;
         }
     }
 

--- a/src/main/java/com/github/alexthe666/iceandfire/entity/tile/TileEntityDragonforgeBrick.java
+++ b/src/main/java/com/github/alexthe666/iceandfire/entity/tile/TileEntityDragonforgeBrick.java
@@ -23,7 +23,7 @@ public class TileEntityDragonforgeBrick extends TileEntity {
 
     private ICapabilityProvider getConnectedTileEntity() {
         for (Direction facing : Direction.values()) {
-            if (world.getTileEntity(pos.offset(facing)) != null && world.getTileEntity(pos.offset(facing)) instanceof TileEntityDragonforge) {
+            if (world.getTileEntity(pos.offset(facing)) instanceof TileEntityDragonforge) {
                 return world.getTileEntity(pos.offset(facing));
             }
         }

--- a/src/main/java/com/github/alexthe666/iceandfire/entity/tile/TileEntityDragonforgeInput.java
+++ b/src/main/java/com/github/alexthe666/iceandfire/entity/tile/TileEntityDragonforgeInput.java
@@ -134,19 +134,20 @@ public class TileEntityDragonforgeInput extends TileEntity implements ITickableT
                 return IafBlockRegistry.DRAGONFORGE_ICE_INPUT.getDefaultState().with(BlockDragonforgeInput.ACTIVE, false);
             case 2:
                 return IafBlockRegistry.DRAGONFORGE_LIGHTNING_INPUT.getDefaultState().with(BlockDragonforgeInput.ACTIVE, false);
-
+            default:
+                return IafBlockRegistry.DRAGONFORGE_FIRE_INPUT.getDefaultState().with(BlockDragonforgeInput.ACTIVE,
+                    false);
         }
-        return IafBlockRegistry.DRAGONFORGE_FIRE_INPUT.getDefaultState().with(BlockDragonforgeInput.ACTIVE, false);
     }
 
     private int getDragonType() {
-        if(world.getBlockState(pos).getBlock() == IafBlockRegistry.DRAGONFORGE_FIRE_INPUT){
+        if (world.getBlockState(pos).getBlock() == IafBlockRegistry.DRAGONFORGE_FIRE_INPUT) {
             return 0;
         }
-        if(world.getBlockState(pos).getBlock() == IafBlockRegistry.DRAGONFORGE_ICE_INPUT){
+        if (world.getBlockState(pos).getBlock() == IafBlockRegistry.DRAGONFORGE_ICE_INPUT) {
             return 1;
         }
-        if(world.getBlockState(pos).getBlock() == IafBlockRegistry.DRAGONFORGE_LIGHTNING_INPUT){
+        if (world.getBlockState(pos).getBlock() == IafBlockRegistry.DRAGONFORGE_LIGHTNING_INPUT) {
             return 2;
         }
         return 0;
@@ -156,26 +157,16 @@ public class TileEntityDragonforgeInput extends TileEntity implements ITickableT
         return world.getBlockState(pos).getBlock() instanceof BlockDragonforgeInput && world.getBlockState(pos).get(BlockDragonforgeInput.ACTIVE);
     }
 
-    private void setActive() {
-        TileEntity tileentity = world.getTileEntity(pos);
-        world.setBlockState(this.pos, getDeactivatedState().with(BlockDragonforgeInput.ACTIVE, true));
-        if (tileentity != null) {
-            tileentity.validate();
-            world.setTileEntity(pos, tileentity);
-        }
-    }
-
     private TileEntityDragonforge getConnectedTileEntity() {
         for (Direction facing : HORIZONTALS) {
-            if (world.getTileEntity(pos.offset(facing)) != null && world.getTileEntity(pos.offset(facing)) instanceof TileEntityDragonforge) {
+            if (world.getTileEntity(pos.offset(facing)) instanceof TileEntityDragonforge) {
                 return (TileEntityDragonforge) world.getTileEntity(pos.offset(facing));
             }
         }
         return null;
     }
-    @SuppressWarnings("unchecked")
     @Override
-    @javax.annotation.Nullable
+    @javax.annotation.Nonnull
     public <T> net.minecraftforge.common.util.LazyOptional<T> getCapability(net.minecraftforge.common.capabilities.Capability<T> capability, @Nullable Direction facing) {
         if (core != null && capability == net.minecraftforge.items.CapabilityItemHandler.ITEM_HANDLER_CAPABILITY) {
             return core.getCapability(capability, facing);

--- a/src/main/java/com/github/alexthe666/iceandfire/entity/tile/TileEntityDreadPortal.java
+++ b/src/main/java/com/github/alexthe666/iceandfire/entity/tile/TileEntityDreadPortal.java
@@ -9,9 +9,6 @@ import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.Direction;
 import net.minecraft.util.math.BlockPos;
 
-import net.minecraftforge.api.distmarker.Dist;
-import net.minecraftforge.api.distmarker.OnlyIn;
-
 public class TileEntityDreadPortal extends TileEntity implements ITickableTileEntity {
     private long age;
     private BlockPos exitPortal;
@@ -50,7 +47,6 @@ public class TileEntityDreadPortal extends TileEntity implements ITickableTileEn
     }
 
     @Override
-    @OnlyIn(Dist.CLIENT)
     public double getMaxRenderDistanceSquared() {
         return 65536.0D;
     }
@@ -75,7 +71,6 @@ public class TileEntityDreadPortal extends TileEntity implements ITickableTileEn
         return this.write(new CompoundNBT());
     }
 
-    @OnlyIn(Dist.CLIENT)
     public boolean shouldRenderFace(Direction face) {
         return true;
     }

--- a/src/main/java/com/github/alexthe666/iceandfire/entity/tile/TileEntityEggInIce.java
+++ b/src/main/java/com/github/alexthe666/iceandfire/entity/tile/TileEntityEggInIce.java
@@ -1,7 +1,7 @@
 package com.github.alexthe666.iceandfire.entity.tile;
 
-import java.util.Random;
 import java.util.UUID;
+import java.util.concurrent.ThreadLocalRandom;
 
 import javax.annotation.Nullable;
 
@@ -104,7 +104,7 @@ public class TileEntityEggInIce extends TileEntity implements ITickableTileEntit
             EntityIceDragon dragon = new EntityIceDragon(world);
             dragon.setPosition(pos.getX() + 0.5, pos.getY() + 1, pos.getZ() + 0.5);
             dragon.setVariant(type.ordinal() - 4);
-            dragon.setGender(new Random().nextBoolean());
+            dragon.setGender(ThreadLocalRandom.current().nextBoolean());
             dragon.setTamed(true);
             dragon.setHunger(50);
             dragon.setOwnerId(ownerUUID);

--- a/src/main/java/com/github/alexthe666/iceandfire/entity/tile/TileEntityGhostChest.java
+++ b/src/main/java/com/github/alexthe666/iceandfire/entity/tile/TileEntityGhostChest.java
@@ -1,6 +1,6 @@
 package com.github.alexthe666.iceandfire.entity.tile;
 
-import java.util.Random;
+import java.util.concurrent.ThreadLocalRandom;
 
 import com.github.alexthe666.iceandfire.entity.EntityGhost;
 import com.github.alexthe666.iceandfire.entity.IafEntityRegistry;
@@ -29,16 +29,18 @@ public class TileEntityGhostChest extends ChestTileEntity {
         super.write(compound);
         return compound;
     }
+
     @Override
     public void openInventory(PlayerEntity player) {
         super.openInventory(player);
-        if(this.world.getDifficulty() != Difficulty.PEACEFUL){
+        if (this.world.getDifficulty() != Difficulty.PEACEFUL) {
             EntityGhost ghost = IafEntityRegistry.GHOST.create(world);
-            Random random = new Random();
-            ghost.setPositionAndRotation(this.pos.getX() + 0.5F, this.pos.getY() + 0.5F, this.pos.getZ() + 0.5F, random.nextFloat() * 360F, 0);
-            if(!this.world.isRemote){
-                ghost.onInitialSpawn((ServerWorld)world, world.getDifficultyForLocation(this.pos), SpawnReason.SPAWNER, null, null);
-                if(!player.isCreative()){
+            ghost.setPositionAndRotation(this.pos.getX() + 0.5F, this.pos.getY() + 0.5F, this.pos.getZ() + 0.5F,
+                ThreadLocalRandom.current().nextFloat() * 360F, 0);
+            if (!this.world.isRemote) {
+                ghost.onInitialSpawn((ServerWorld) world, world.getDifficultyForLocation(this.pos), SpawnReason.SPAWNER,
+                    null, null);
+                if (!player.isCreative()) {
                     ghost.setAttackTarget(player);
                 }
                 ghost.enablePersistence();
@@ -54,6 +56,5 @@ public class TileEntityGhostChest extends ChestTileEntity {
     protected void onOpenOrClose() {
         super.onOpenOrClose();
         this.world.notifyNeighborsOfStateChange(this.pos.down(), this.getBlockState().getBlock());
-
     }
 }

--- a/src/main/java/com/github/alexthe666/iceandfire/entity/tile/TileEntityGhostChest.java
+++ b/src/main/java/com/github/alexthe666/iceandfire/entity/tile/TileEntityGhostChest.java
@@ -38,8 +38,7 @@ public class TileEntityGhostChest extends ChestTileEntity {
             ghost.setPositionAndRotation(this.pos.getX() + 0.5F, this.pos.getY() + 0.5F, this.pos.getZ() + 0.5F,
                 ThreadLocalRandom.current().nextFloat() * 360F, 0);
             if (!this.world.isRemote) {
-                ghost.onInitialSpawn((ServerWorld) world, world.getDifficultyForLocation(this.pos), SpawnReason.SPAWNER,
-                    null, null);
+                ghost.onInitialSpawn((ServerWorld) world, world.getDifficultyForLocation(this.pos), SpawnReason.SPAWNER, null, null);
                 if (!player.isCreative()) {
                     ghost.setAttackTarget(player);
                 }

--- a/src/main/java/com/github/alexthe666/iceandfire/entity/tile/TileEntityGhostChest.java
+++ b/src/main/java/com/github/alexthe666/iceandfire/entity/tile/TileEntityGhostChest.java
@@ -1,6 +1,6 @@
 package com.github.alexthe666.iceandfire.entity.tile;
 
-import java.util.Random;
+import java.util.concurrent.ThreadLocalRandom;
 
 import com.github.alexthe666.iceandfire.entity.EntityGhost;
 import com.github.alexthe666.iceandfire.entity.IafEntityRegistry;
@@ -29,16 +29,18 @@ public class TileEntityGhostChest extends ChestTileEntity {
         super.write(compound);
         return compound;
     }
+
     @Override
     public void openInventory(PlayerEntity player) {
         super.openInventory(player);
-        if(this.world.getDifficulty() != Difficulty.PEACEFUL){
+        if (this.world.getDifficulty() != Difficulty.PEACEFUL) {
             EntityGhost ghost = IafEntityRegistry.GHOST.get().create(world);
-            Random random = new Random();
-            ghost.setPositionAndRotation(this.pos.getX() + 0.5F, this.pos.getY() + 0.5F, this.pos.getZ() + 0.5F, random.nextFloat() * 360F, 0);
-            if(!this.world.isRemote){
-                ghost.onInitialSpawn((ServerWorld)world, world.getDifficultyForLocation(this.pos), SpawnReason.SPAWNER, null, null);
-                if(!player.isCreative()){
+            ghost.setPositionAndRotation(this.pos.getX() + 0.5F, this.pos.getY() + 0.5F, this.pos.getZ() + 0.5F,
+                ThreadLocalRandom.current().nextFloat() * 360F, 0);
+            if (!this.world.isRemote) {
+                ghost.onInitialSpawn((ServerWorld) world, world.getDifficultyForLocation(this.pos), SpawnReason.SPAWNER,
+                    null, null);
+                if (!player.isCreative()) {
                     ghost.setAttackTarget(player);
                 }
                 ghost.enablePersistence();
@@ -54,6 +56,5 @@ public class TileEntityGhostChest extends ChestTileEntity {
     protected void onOpenOrClose() {
         super.onOpenOrClose();
         this.world.notifyNeighborsOfStateChange(this.pos.down(), this.getBlockState().getBlock());
-
     }
 }

--- a/src/main/java/com/github/alexthe666/iceandfire/entity/tile/TileEntityJar.java
+++ b/src/main/java/com/github/alexthe666/iceandfire/entity/tile/TileEntityJar.java
@@ -41,7 +41,8 @@ public class TileEntityJar extends TileEntity implements ITickableTileEntity {
     public NonNullList<ItemStack> pixieItems = NonNullList.withSize(1, ItemStack.EMPTY);
     public float rotationYaw;
     public float prevRotationYaw;
-    net.minecraftforge.common.util.LazyOptional<? extends net.minecraftforge.items.IItemHandler> downHandler = PixieJarInvWrapper.create(this, Direction.DOWN);
+    net.minecraftforge.common.util.LazyOptional<? extends net.minecraftforge.items.IItemHandler> downHandler = PixieJarInvWrapper
+        .create(this);
     private Random rand;
 
     public TileEntityJar() {
@@ -108,7 +109,7 @@ public class TileEntityJar extends TileEntity implements ITickableTileEntity {
     public void tick() {
         ticksExisted++;
         if (this.world.isRemote && this.hasPixie) {
-            IceAndFire.PROXY.spawnParticle(EnumParticles.If_Pixie, this.pos.getX() + 0.5F + (double) (this.rand.nextFloat() * PARTICLE_WIDTH * 2F) - (double) PARTICLE_WIDTH, this.pos.getY() + (double) (this.rand.nextFloat() * PARTICLE_HEIGHT), this.pos.getZ() + 0.5F + (double) (this.rand.nextFloat() * PARTICLE_WIDTH * 2F) - (double) PARTICLE_WIDTH, EntityPixie.PARTICLE_RGB[this.pixieType][0], EntityPixie.PARTICLE_RGB[this.pixieType][1], EntityPixie.PARTICLE_RGB[this.pixieType][2]);
+            IceAndFire.PROXY.spawnParticle(EnumParticles.If_Pixie, this.pos.getX() + 0.5F + (double) (this.rand.nextFloat() * PARTICLE_WIDTH * 2F) - PARTICLE_WIDTH, this.pos.getY() + (double) (this.rand.nextFloat() * PARTICLE_HEIGHT), this.pos.getZ() + 0.5F + (double) (this.rand.nextFloat() * PARTICLE_WIDTH * 2F) - PARTICLE_WIDTH, EntityPixie.PARTICLE_RGB[this.pixieType][0], EntityPixie.PARTICLE_RGB[this.pixieType][1], EntityPixie.PARTICLE_RGB[this.pixieType][2]);
         }
         if (ticksExisted % 24000 == 0 && !this.hasProduced && this.hasPixie) {
             this.hasProduced = true;
@@ -152,7 +153,8 @@ public class TileEntityJar extends TileEntity implements ITickableTileEntity {
 
     @Override
     public <T> net.minecraftforge.common.util.LazyOptional<T> getCapability(net.minecraftforge.common.capabilities.Capability<T> capability, @Nullable Direction facing) {
-        if (facing != null && capability == net.minecraftforge.items.CapabilityItemHandler.ITEM_HANDLER_CAPABILITY)
+        if (facing == Direction.DOWN
+            && capability == net.minecraftforge.items.CapabilityItemHandler.ITEM_HANDLER_CAPABILITY)
             return downHandler.cast();
         return super.getCapability(capability, facing);
     }

--- a/src/main/java/com/github/alexthe666/iceandfire/entity/tile/TileEntityJar.java
+++ b/src/main/java/com/github/alexthe666/iceandfire/entity/tile/TileEntityJar.java
@@ -42,7 +42,8 @@ public class TileEntityJar extends TileEntity implements ITickableTileEntity {
     public NonNullList<ItemStack> pixieItems = NonNullList.withSize(1, ItemStack.EMPTY);
     public float rotationYaw;
     public float prevRotationYaw;
-    net.minecraftforge.common.util.LazyOptional<? extends net.minecraftforge.items.IItemHandler> downHandler = PixieJarInvWrapper.create(this, Direction.DOWN);
+    net.minecraftforge.common.util.LazyOptional<? extends net.minecraftforge.items.IItemHandler> downHandler = PixieJarInvWrapper
+        .create(this);
     private Random rand;
 
     public TileEntityJar() {
@@ -109,7 +110,7 @@ public class TileEntityJar extends TileEntity implements ITickableTileEntity {
     public void tick() {
         ticksExisted++;
         if (this.world.isRemote && this.hasPixie) {
-            IceAndFire.PROXY.spawnParticle(EnumParticles.If_Pixie, this.pos.getX() + 0.5F + (double) (this.rand.nextFloat() * PARTICLE_WIDTH * 2F) - (double) PARTICLE_WIDTH, this.pos.getY() + (double) (this.rand.nextFloat() * PARTICLE_HEIGHT), this.pos.getZ() + 0.5F + (double) (this.rand.nextFloat() * PARTICLE_WIDTH * 2F) - (double) PARTICLE_WIDTH, EntityPixie.PARTICLE_RGB[this.pixieType][0], EntityPixie.PARTICLE_RGB[this.pixieType][1], EntityPixie.PARTICLE_RGB[this.pixieType][2]);
+            IceAndFire.PROXY.spawnParticle(EnumParticles.If_Pixie, this.pos.getX() + 0.5F + (double) (this.rand.nextFloat() * PARTICLE_WIDTH * 2F) - PARTICLE_WIDTH, this.pos.getY() + (double) (this.rand.nextFloat() * PARTICLE_HEIGHT), this.pos.getZ() + 0.5F + (double) (this.rand.nextFloat() * PARTICLE_WIDTH * 2F) - PARTICLE_WIDTH, EntityPixie.PARTICLE_RGB[this.pixieType][0], EntityPixie.PARTICLE_RGB[this.pixieType][1], EntityPixie.PARTICLE_RGB[this.pixieType][2]);
         }
         if (ticksExisted % 24000 == 0 && !this.hasProduced && this.hasPixie) {
             this.hasProduced = true;
@@ -153,7 +154,8 @@ public class TileEntityJar extends TileEntity implements ITickableTileEntity {
 
     @Override
     public <T> net.minecraftforge.common.util.LazyOptional<T> getCapability(net.minecraftforge.common.capabilities.Capability<T> capability, @Nullable Direction facing) {
-        if (facing != null && capability == net.minecraftforge.items.CapabilityItemHandler.ITEM_HANDLER_CAPABILITY)
+        if (facing == Direction.DOWN
+            && capability == net.minecraftforge.items.CapabilityItemHandler.ITEM_HANDLER_CAPABILITY)
             return downHandler.cast();
         return super.getCapability(capability, facing);
     }

--- a/src/main/java/com/github/alexthe666/iceandfire/entity/tile/TileEntityLectern.java
+++ b/src/main/java/com/github/alexthe666/iceandfire/entity/tile/TileEntityLectern.java
@@ -94,36 +94,10 @@ public class TileEntityLectern extends LockableTileEntity implements ITickableTi
         return this.stacks.get(index);
     }
 
-    private boolean canAddPage() {
-        if (this.stacks.get(0).isEmpty()) {
-            return false;
-        } else {
-            ItemStack itemstack = this.stacks.get(0).copy();
-
-            if (itemstack.isEmpty()) {
-                return false;
-            }
-            if (itemstack.getItem() != IafItemRegistry.BESTIARY) {
-                return false;
-            }
-
-            if (itemstack.getItem() == IafItemRegistry.BESTIARY) {
-                List list = EnumBestiaryPages.possiblePages(itemstack);
-                if (list == null || list.isEmpty()) {
-                    return false;
-                }
-            }
-            if (this.stacks.get(2).isEmpty())
-                return true;
-            int result = stacks.get(2).getCount() + itemstack.getCount();
-            return result <= getInventoryStackLimit() && result <= this.stacks.get(2).getMaxStackSize();
-        }
-    }
-
-    private ArrayList<EnumBestiaryPages> getPossiblePages() {
-        List list = EnumBestiaryPages.possiblePages(this.stacks.get(0));
+    private List<EnumBestiaryPages> getPossiblePages() {
+        final List<EnumBestiaryPages> list = EnumBestiaryPages.possiblePages(this.stacks.get(0));
         if (list != null && !list.isEmpty()) {
-            return (ArrayList<EnumBestiaryPages>) list;
+            return list;
         }
         return EMPTY_LIST;
     }
@@ -181,7 +155,7 @@ public class TileEntityLectern extends LockableTileEntity implements ITickableTi
                 List<EnumBestiaryPages> possibleList = getPossiblePages();
                 localRand.setSeed(this.world.getGameTime());
                 Collections.shuffle(possibleList, localRand);
-                if (possibleList.size() > 0) {
+                if (!possibleList.isEmpty()) {
                     selectedPages[0] = possibleList.get(0);
                 } else {
                     selectedPages[0] = null;
@@ -273,8 +247,8 @@ public class TileEntityLectern extends LockableTileEntity implements ITickableTi
         return this.isItemValidForSlot(index, itemStackIn);
     }
 
-    public String getGuiID() {
-        return "iceandfire:lectern";
+    public static String getGuiID() {
+        return IceAndFire.MODID + ":lectern";
     }
 
     @Override

--- a/src/main/java/com/github/alexthe666/iceandfire/entity/tile/TileEntityMyrmexCocoon.java
+++ b/src/main/java/com/github/alexthe666/iceandfire/entity/tile/TileEntityMyrmexCocoon.java
@@ -22,7 +22,6 @@ import net.minecraft.util.text.TranslationTextComponent;
 
 public class TileEntityMyrmexCocoon extends LockableLootTileEntity {
 
-
     private NonNullList<ItemStack> chestContents = NonNullList.withSize(18, ItemStack.EMPTY);
 
     public TileEntityMyrmexCocoon() {

--- a/src/main/java/com/github/alexthe666/iceandfire/entity/tile/TileEntityPixieHouse.java
+++ b/src/main/java/com/github/alexthe666/iceandfire/entity/tile/TileEntityPixieHouse.java
@@ -43,13 +43,13 @@ public class TileEntityPixieHouse extends TileEntity implements ITickableTileEnt
     }
 
     public static int getHouseTypeFromBlock(Block block) {
-        if (block == IafBlockRegistry.PIXIE_HOUSE_MUSHROOM_RED) { return 1; }
-        if (block == IafBlockRegistry.PIXIE_HOUSE_MUSHROOM_BROWN) { return 0; }
-        if (block == IafBlockRegistry.PIXIE_HOUSE_OAK) { return 3; }
-        if (block == IafBlockRegistry.PIXIE_HOUSE_BIRCH) { return 2; }
-        if (block == IafBlockRegistry.PIXIE_HOUSE_SPRUCE) { return 5; }
-        if (block == IafBlockRegistry.PIXIE_HOUSE_DARK_OAK) { return 4; }
-        return 0;
+        if (block == IafBlockRegistry.PIXIE_HOUSE_MUSHROOM_RED) return 1;
+        if (block == IafBlockRegistry.PIXIE_HOUSE_MUSHROOM_BROWN) return 0;
+        if (block == IafBlockRegistry.PIXIE_HOUSE_OAK) return 3;
+        if (block == IafBlockRegistry.PIXIE_HOUSE_BIRCH) return 2;
+        if (block == IafBlockRegistry.PIXIE_HOUSE_SPRUCE) return 5;
+        if (block == IafBlockRegistry.PIXIE_HOUSE_DARK_OAK) return 4;
+        else return 0;
     }
 
     @Override

--- a/src/main/java/com/github/alexthe666/iceandfire/entity/tile/TileEntityPixieHouse.java
+++ b/src/main/java/com/github/alexthe666/iceandfire/entity/tile/TileEntityPixieHouse.java
@@ -2,6 +2,7 @@ package com.github.alexthe666.iceandfire.entity.tile;
 
 import java.util.Random;
 import java.util.UUID;
+import java.util.concurrent.ThreadLocalRandom;
 
 import com.github.alexthe666.iceandfire.IceAndFire;
 import com.github.alexthe666.iceandfire.block.IafBlockRegistry;
@@ -42,24 +43,12 @@ public class TileEntityPixieHouse extends TileEntity implements ITickableTileEnt
     }
 
     public static int getHouseTypeFromBlock(Block block) {
-        if (block == IafBlockRegistry.PIXIE_HOUSE_MUSHROOM_RED) {
-            return 1;
-        }
-        if (block == IafBlockRegistry.PIXIE_HOUSE_MUSHROOM_BROWN) {
-            return 0;
-        }
-        if (block == IafBlockRegistry.PIXIE_HOUSE_OAK) {
-            return 3;
-        }
-        if (block == IafBlockRegistry.PIXIE_HOUSE_BIRCH) {
-            return 2;
-        }
-        if (block == IafBlockRegistry.PIXIE_HOUSE_SPRUCE) {
-            return 5;
-        }
-        if (block == IafBlockRegistry.PIXIE_HOUSE_DARK_OAK) {
-            return 4;
-        }
+        if (block == IafBlockRegistry.PIXIE_HOUSE_MUSHROOM_RED) { return 1; }
+        if (block == IafBlockRegistry.PIXIE_HOUSE_MUSHROOM_BROWN) { return 0; }
+        if (block == IafBlockRegistry.PIXIE_HOUSE_OAK) { return 3; }
+        if (block == IafBlockRegistry.PIXIE_HOUSE_BIRCH) { return 2; }
+        if (block == IafBlockRegistry.PIXIE_HOUSE_SPRUCE) { return 5; }
+        if (block == IafBlockRegistry.PIXIE_HOUSE_DARK_OAK) { return 4; }
         return 0;
     }
 
@@ -86,7 +75,8 @@ public class TileEntityPixieHouse extends TileEntity implements ITickableTileEnt
     public void onDataPacket(NetworkManager net, SUpdateTileEntityPacket packet) {
         read(this.getBlockState(), packet.getNbtCompound());
         if (!world.isRemote) {
-            IceAndFire.sendMSGToAll(new MessageUpdatePixieHouseModel(pos.toLong(), packet.getNbtCompound().getInt("HouseType")));
+            IceAndFire.sendMSGToAll(
+                new MessageUpdatePixieHouseModel(pos.toLong(), packet.getNbtCompound().getInt("HouseType")));
         }
     }
 
@@ -101,7 +91,7 @@ public class TileEntityPixieHouse extends TileEntity implements ITickableTileEnt
         hasPixie = compound.getBoolean("HasPixie");
         pixieType = compound.getInt("PixieType");
         tamedPixie = compound.getBoolean("TamedPixie");
-        if(compound.hasUniqueId("PixieOwnerUUID")){
+        if (compound.hasUniqueId("PixieOwnerUUID")) {
             pixieOwnerUUID = compound.getUniqueId("PixieOwnerUUID");
         }
         this.pixieItems = NonNullList.withSize(1, ItemStack.EMPTY);
@@ -112,17 +102,23 @@ public class TileEntityPixieHouse extends TileEntity implements ITickableTileEnt
     @Override
     public void tick() {
         ticksExisted++;
-        if (!world.isRemote && this.hasPixie && new Random().nextInt(100) == 0) {
+        if (!world.isRemote && this.hasPixie && ThreadLocalRandom.current().nextInt(100) == 0) {
             releasePixie();
         }
         if (this.world.isRemote && this.hasPixie) {
-            IceAndFire.PROXY.spawnParticle(EnumParticles.If_Pixie, this.pos.getX() + 0.5F + (double) (this.rand.nextFloat() * PARTICLE_WIDTH * 2F) - (double) PARTICLE_WIDTH, this.pos.getY() + (double) (this.rand.nextFloat() * PARTICLE_HEIGHT), this.pos.getZ() + 0.5F + (double) (this.rand.nextFloat() * PARTICLE_WIDTH * 2F) - (double) PARTICLE_WIDTH, EntityPixie.PARTICLE_RGB[this.pixieType][0], EntityPixie.PARTICLE_RGB[this.pixieType][1], EntityPixie.PARTICLE_RGB[this.pixieType][2]);
+            IceAndFire.PROXY.spawnParticle(EnumParticles.If_Pixie,
+                this.pos.getX() + 0.5F + (double) (this.rand.nextFloat() * PARTICLE_WIDTH * 2F) - PARTICLE_WIDTH,
+                this.pos.getY() + (double) (this.rand.nextFloat() * PARTICLE_HEIGHT),
+                this.pos.getZ() + 0.5F + (double) (this.rand.nextFloat() * PARTICLE_WIDTH * 2F) - PARTICLE_WIDTH,
+                EntityPixie.PARTICLE_RGB[this.pixieType][0], EntityPixie.PARTICLE_RGB[this.pixieType][1],
+                EntityPixie.PARTICLE_RGB[this.pixieType][2]);
         }
     }
 
     public void releasePixie() {
         EntityPixie pixie = new EntityPixie(IafEntityRegistry.PIXIE, this.world);
-        pixie.setPositionAndRotation(this.pos.getX() + 0.5F, this.pos.getY() + 1F, this.pos.getZ() + 0.5F, new Random().nextInt(360), 0);
+        pixie.setPositionAndRotation(this.pos.getX() + 0.5F, this.pos.getY() + 1F, this.pos.getZ() + 0.5F,
+            ThreadLocalRandom.current().nextInt(360), 0);
         pixie.setHeldItem(Hand.MAIN_HAND, pixieItems.get(0));
         pixie.setColor(this.pixieType);
         if (!world.isRemote) {

--- a/src/main/java/com/github/alexthe666/iceandfire/entity/tile/TileEntityPixieHouse.java
+++ b/src/main/java/com/github/alexthe666/iceandfire/entity/tile/TileEntityPixieHouse.java
@@ -2,6 +2,7 @@ package com.github.alexthe666.iceandfire.entity.tile;
 
 import java.util.Random;
 import java.util.UUID;
+import java.util.concurrent.ThreadLocalRandom;
 
 import com.github.alexthe666.iceandfire.IceAndFire;
 import com.github.alexthe666.iceandfire.block.IafBlockRegistry;
@@ -42,24 +43,12 @@ public class TileEntityPixieHouse extends TileEntity implements ITickableTileEnt
     }
 
     public static int getHouseTypeFromBlock(Block block) {
-        if (block == IafBlockRegistry.PIXIE_HOUSE_MUSHROOM_RED) {
-            return 1;
-        }
-        if (block == IafBlockRegistry.PIXIE_HOUSE_MUSHROOM_BROWN) {
-            return 0;
-        }
-        if (block == IafBlockRegistry.PIXIE_HOUSE_OAK) {
-            return 3;
-        }
-        if (block == IafBlockRegistry.PIXIE_HOUSE_BIRCH) {
-            return 2;
-        }
-        if (block == IafBlockRegistry.PIXIE_HOUSE_SPRUCE) {
-            return 5;
-        }
-        if (block == IafBlockRegistry.PIXIE_HOUSE_DARK_OAK) {
-            return 4;
-        }
+        if (block == IafBlockRegistry.PIXIE_HOUSE_MUSHROOM_RED) { return 1; }
+        if (block == IafBlockRegistry.PIXIE_HOUSE_MUSHROOM_BROWN) { return 0; }
+        if (block == IafBlockRegistry.PIXIE_HOUSE_OAK) { return 3; }
+        if (block == IafBlockRegistry.PIXIE_HOUSE_BIRCH) { return 2; }
+        if (block == IafBlockRegistry.PIXIE_HOUSE_SPRUCE) { return 5; }
+        if (block == IafBlockRegistry.PIXIE_HOUSE_DARK_OAK) { return 4; }
         return 0;
     }
 
@@ -86,7 +75,8 @@ public class TileEntityPixieHouse extends TileEntity implements ITickableTileEnt
     public void onDataPacket(NetworkManager net, SUpdateTileEntityPacket packet) {
         read(this.getBlockState(), packet.getNbtCompound());
         if (!world.isRemote) {
-            IceAndFire.sendMSGToAll(new MessageUpdatePixieHouseModel(pos.toLong(), packet.getNbtCompound().getInt("HouseType")));
+            IceAndFire.sendMSGToAll(
+                new MessageUpdatePixieHouseModel(pos.toLong(), packet.getNbtCompound().getInt("HouseType")));
         }
     }
 
@@ -101,7 +91,7 @@ public class TileEntityPixieHouse extends TileEntity implements ITickableTileEnt
         hasPixie = compound.getBoolean("HasPixie");
         pixieType = compound.getInt("PixieType");
         tamedPixie = compound.getBoolean("TamedPixie");
-        if(compound.hasUniqueId("PixieOwnerUUID")){
+        if (compound.hasUniqueId("PixieOwnerUUID")) {
             pixieOwnerUUID = compound.getUniqueId("PixieOwnerUUID");
         }
         this.pixieItems = NonNullList.withSize(1, ItemStack.EMPTY);
@@ -112,17 +102,23 @@ public class TileEntityPixieHouse extends TileEntity implements ITickableTileEnt
     @Override
     public void tick() {
         ticksExisted++;
-        if (!world.isRemote && this.hasPixie && new Random().nextInt(100) == 0) {
+        if (!world.isRemote && this.hasPixie && ThreadLocalRandom.current().nextInt(100) == 0) {
             releasePixie();
         }
         if (this.world.isRemote && this.hasPixie) {
-            IceAndFire.PROXY.spawnParticle(EnumParticles.If_Pixie, this.pos.getX() + 0.5F + (double) (this.rand.nextFloat() * PARTICLE_WIDTH * 2F) - (double) PARTICLE_WIDTH, this.pos.getY() + (double) (this.rand.nextFloat() * PARTICLE_HEIGHT), this.pos.getZ() + 0.5F + (double) (this.rand.nextFloat() * PARTICLE_WIDTH * 2F) - (double) PARTICLE_WIDTH, EntityPixie.PARTICLE_RGB[this.pixieType][0], EntityPixie.PARTICLE_RGB[this.pixieType][1], EntityPixie.PARTICLE_RGB[this.pixieType][2]);
+            IceAndFire.PROXY.spawnParticle(EnumParticles.If_Pixie,
+                this.pos.getX() + 0.5F + (double) (this.rand.nextFloat() * PARTICLE_WIDTH * 2F) - PARTICLE_WIDTH,
+                this.pos.getY() + (double) (this.rand.nextFloat() * PARTICLE_HEIGHT),
+                this.pos.getZ() + 0.5F + (double) (this.rand.nextFloat() * PARTICLE_WIDTH * 2F) - PARTICLE_WIDTH,
+                EntityPixie.PARTICLE_RGB[this.pixieType][0], EntityPixie.PARTICLE_RGB[this.pixieType][1],
+                EntityPixie.PARTICLE_RGB[this.pixieType][2]);
         }
     }
 
     public void releasePixie() {
         EntityPixie pixie = new EntityPixie(IafEntityRegistry.PIXIE.get(), this.world);
-        pixie.setPositionAndRotation(this.pos.getX() + 0.5F, this.pos.getY() + 1F, this.pos.getZ() + 0.5F, new Random().nextInt(360), 0);
+        pixie.setPositionAndRotation(this.pos.getX() + 0.5F, this.pos.getY() + 1F, this.pos.getZ() + 0.5F,
+            ThreadLocalRandom.current().nextInt(360), 0);
         pixie.setHeldItem(Hand.MAIN_HAND, pixieItems.get(0));
         pixie.setColor(this.pixieType);
         if (!world.isRemote) {

--- a/src/main/java/com/github/alexthe666/iceandfire/entity/tile/TileEntityPodium.java
+++ b/src/main/java/com/github/alexthe666/iceandfire/entity/tile/TileEntityPodium.java
@@ -25,19 +25,17 @@ import net.minecraft.util.IntArray;
 import net.minecraft.util.NonNullList;
 import net.minecraft.util.text.ITextComponent;
 import net.minecraft.util.text.TranslationTextComponent;
+import net.minecraftforge.items.IItemHandler;
+import net.minecraftforge.items.wrapper.SidedInvWrapper;
 
 public class TileEntityPodium extends LockableTileEntity implements ITickableTileEntity, ISidedInventory {
 
-    private static final int[] slotsTop = new int[] {
-        0
-    };
+    private static final int[] slotsTop = new int[] {0};
     public int ticksExisted;
     public int prevTicksExisted;
-    net.minecraftforge.items.IItemHandler handlerUp = new net.minecraftforge.items.wrapper.SidedInvWrapper(this,
-        net.minecraft.util.Direction.UP);
-    net.minecraftforge.items.IItemHandler handlerDown = new net.minecraftforge.items.wrapper.SidedInvWrapper(this,
-        Direction.DOWN);
-    net.minecraftforge.common.util.LazyOptional<? extends net.minecraftforge.items.IItemHandler>[] handlers = net.minecraftforge.items.wrapper.SidedInvWrapper
+    IItemHandler handlerUp = new SidedInvWrapper(this, net.minecraft.util.Direction.UP);
+    IItemHandler handlerDown = new SidedInvWrapper(this, Direction.DOWN);
+    net.minecraftforge.common.util.LazyOptional<? extends IItemHandler>[] handlers = SidedInvWrapper
         .create(this, Direction.UP, Direction.DOWN);
     private NonNullList<ItemStack> stacks = NonNullList.withSize(1, ItemStack.EMPTY);
 
@@ -212,7 +210,8 @@ public class TileEntityPodium extends LockableTileEntity implements ITickableTil
     @Override
     public boolean isEmpty() {
         for (int i = 0; i < this.getSizeInventory(); i++) {
-            if (!this.getStackInSlot(i).isEmpty()) { return false; }
+            if (!this.getStackInSlot(i).isEmpty())
+                return false;
         }
         return true;
     }

--- a/src/main/java/com/github/alexthe666/iceandfire/entity/tile/TileEntityPodium.java
+++ b/src/main/java/com/github/alexthe666/iceandfire/entity/tile/TileEntityPodium.java
@@ -26,17 +26,19 @@ import net.minecraft.util.NonNullList;
 import net.minecraft.util.text.ITextComponent;
 import net.minecraft.util.text.TranslationTextComponent;
 
-import net.minecraftforge.api.distmarker.Dist;
-import net.minecraftforge.api.distmarker.OnlyIn;
-
 public class TileEntityPodium extends LockableTileEntity implements ITickableTileEntity, ISidedInventory {
-    private static final int[] slotsTop = new int[]{0};
+
+    private static final int[] slotsTop = new int[] {
+        0
+    };
     public int ticksExisted;
     public int prevTicksExisted;
-    net.minecraftforge.items.IItemHandler handlerUp = new net.minecraftforge.items.wrapper.SidedInvWrapper(this, net.minecraft.util.Direction.UP);
-    net.minecraftforge.items.IItemHandler handlerDown = new net.minecraftforge.items.wrapper.SidedInvWrapper(this, Direction.DOWN);
-    net.minecraftforge.common.util.LazyOptional<? extends net.minecraftforge.items.IItemHandler>[] handlers =
-            net.minecraftforge.items.wrapper.SidedInvWrapper.create(this, Direction.UP, Direction.DOWN);
+    net.minecraftforge.items.IItemHandler handlerUp = new net.minecraftforge.items.wrapper.SidedInvWrapper(this,
+        net.minecraft.util.Direction.UP);
+    net.minecraftforge.items.IItemHandler handlerDown = new net.minecraftforge.items.wrapper.SidedInvWrapper(this,
+        Direction.DOWN);
+    net.minecraftforge.common.util.LazyOptional<? extends net.minecraftforge.items.IItemHandler>[] handlers = net.minecraftforge.items.wrapper.SidedInvWrapper
+        .create(this, Direction.UP, Direction.DOWN);
     private NonNullList<ItemStack> stacks = NonNullList.withSize(1, ItemStack.EMPTY);
 
     public TileEntityPodium() {
@@ -50,7 +52,6 @@ public class TileEntityPodium extends LockableTileEntity implements ITickableTil
     }
 
     @Override
-    @OnlyIn(Dist.CLIENT)
     public net.minecraft.util.math.AxisAlignedBB getRenderBoundingBox() {
         return new net.minecraft.util.math.AxisAlignedBB(pos, pos.add(1, 3, 1));
     }
@@ -100,14 +101,13 @@ public class TileEntityPodium extends LockableTileEntity implements ITickableTil
 
     @Override
     public void setInventorySlotContents(int index, ItemStack stack) {
-        boolean flag = !stack.isEmpty() && stack.isItemEqual(this.stacks.get(index)) && ItemStack.areItemStackTagsEqual(stack, this.stacks.get(index));
         this.stacks.set(index, stack);
 
         if (!stack.isEmpty() && stack.getCount() > this.getInventoryStackLimit()) {
             stack.setCount(this.getInventoryStackLimit());
         }
         this.write(this.getUpdateTag());
-        if(!world.isRemote){
+        if (!world.isRemote) {
             IceAndFire.sendMSGToAll(new MessageUpdatePodium(this.getPos().toLong(), stacks.get(0)));
         }
     }
@@ -212,16 +212,16 @@ public class TileEntityPodium extends LockableTileEntity implements ITickableTil
     @Override
     public boolean isEmpty() {
         for (int i = 0; i < this.getSizeInventory(); i++) {
-            if (!this.getStackInSlot(i).isEmpty()) {
-                return false;
-            }
+            if (!this.getStackInSlot(i).isEmpty()) { return false; }
         }
         return true;
     }
 
     @Override
-    public <T> net.minecraftforge.common.util.LazyOptional<T> getCapability(net.minecraftforge.common.capabilities.Capability<T> capability, @Nullable Direction facing) {
-        if (!this.removed && facing != null && capability == net.minecraftforge.items.CapabilityItemHandler.ITEM_HANDLER_CAPABILITY) {
+    public <T> net.minecraftforge.common.util.LazyOptional<T> getCapability(
+        net.minecraftforge.common.capabilities.Capability<T> capability, @Nullable Direction facing) {
+        if (!this.removed && facing != null
+            && capability == net.minecraftforge.items.CapabilityItemHandler.ITEM_HANDLER_CAPABILITY) {
             if (facing == Direction.DOWN)
                 return handlers[1].cast();
             else

--- a/src/main/java/com/github/alexthe666/iceandfire/enums/EnumBestiaryPages.java
+++ b/src/main/java/com/github/alexthe666/iceandfire/enums/EnumBestiaryPages.java
@@ -100,7 +100,7 @@ public enum EnumBestiaryPages {
         boolean flag = false;
         if (book.getItem() instanceof ItemBestiary) {
             CompoundNBT tag = book.getTag();
-            final List<Integer> already = Ints.asList(tag.getIntArray("Pages"));
+            final List<Integer> already = new ArrayList<>(Ints.asList(tag.getIntArray("Pages")));
             if (!already.contains(page.ordinal())) {
                 already.add(page.ordinal());
                 flag = true;


### PR DESCRIPTION
This PR optimises and cleans up tile entities by:
- replacing if-chains with `switch` statements where possible
- replacing new instances of `Random` with `ThreadLocalRandom.current`
- replacing data types where necessary (`int`s with `short`s)
- removing unneeded local variables and fields