### PR TITLE
Config option to disable myrmex hive daytime check

### DIFF
--- a/src/main/java/com/github/alexthe666/iceandfire/IafConfig.java
+++ b/src/main/java/com/github/alexthe666/iceandfire/IafConfig.java
@@ -121,6 +121,7 @@ public class IafConfig {
     public static int myrmexColonyGenChance = 150;
     public static int myrmexColonySize = 80;
     public static int myrmexMaximumWanderRadius = 50;
+    public static boolean myrmexHiveIgnoreDaytime = false;
     public static double myrmexBaseAttackStrength = 3.0D;
     public static boolean spawnAmphitheres = true;
     public static int amphithereSpawnRate = 50;
@@ -290,6 +291,7 @@ public class IafConfig {
             myrmexColonySize = ConfigHolder.SERVER.myrmexColonySize.get();
             myrmexBaseAttackStrength = ConfigHolder.SERVER.myrmexBaseAttackStrength.get();
             myrmexMaximumWanderRadius = ConfigHolder.SERVER.myrmexMaximumWanderRadius.get();
+            myrmexHiveIgnoreDaytime = ConfigHolder.SERVER.myrmexHiveIgnoreDaytime.get();
             spawnAmphitheres = ConfigHolder.SERVER.spawnAmphitheres.get();
             amphithereSpawnRate = ConfigHolder.SERVER.amphithereSpawnRate.get();
             amphithereVillagerSearchLength = ConfigHolder.SERVER.amphithereVillagerSearchLength.get();

--- a/src/main/java/com/github/alexthe666/iceandfire/config/ServerConfig.java
+++ b/src/main/java/com/github/alexthe666/iceandfire/config/ServerConfig.java
@@ -108,6 +108,7 @@ public class ServerConfig {
     public final ForgeConfigSpec.IntValue myrmexColonySize;
     public final ForgeConfigSpec.DoubleValue myrmexBaseAttackStrength ;
     public final ForgeConfigSpec.IntValue myrmexMaximumWanderRadius;
+    public final ForgeConfigSpec.BooleanValue myrmexHiveIgnoreDaytime;
     public final ForgeConfigSpec.BooleanValue spawnAmphitheres;
     public final ForgeConfigSpec.IntValue amphithereSpawnRate;
     public final ForgeConfigSpec.IntValue amphithereVillagerSearchLength ;
@@ -338,6 +339,7 @@ public class ServerConfig {
         this.myrmexColonySize = buildInt(builder, "Myrmex Colony Max Size", "all", 80, 10, 10000, "How many maximum individuals a myrmex colony can have.");
         this.myrmexBaseAttackStrength = buildDouble(builder, "Myrmex Base Attack Strength", "all", 3, 1, 10000, "Base Myrmex(worker) attack strength");
         this.myrmexMaximumWanderRadius = buildInt(builder,"Myrmex Maximum Wander Radius","all",50,25,4000,"The maximum radius myrmex area allowed to wander/forage");
+        this.myrmexHiveIgnoreDaytime = buildBoolean(builder, "Myrmex Hive Ignore Daytime", "all", false, "Myrmex hives will ignore daytime");
         builder.pop();
         builder.push("Amphitheres");
         this.spawnAmphitheres = buildBoolean(builder, "Spawn Amphitheres", "all", true, "True if amphitheres are allowed to spawn");

--- a/src/main/java/com/github/alexthe666/iceandfire/entity/EntityMyrmexWorker.java
+++ b/src/main/java/com/github/alexthe666/iceandfire/entity/EntityMyrmexWorker.java
@@ -200,7 +200,7 @@ public class EntityMyrmexWorker extends EntityMyrmexBase {
 
     @Override
     public boolean shouldEnterHive() {
-        return holdingSomething() || !world.isDaytime();
+        return holdingSomething() || (!world.isDaytime() && !IafConfig.myrmexHiveIgnoreDaytime);
     }
 
     @Override


### PR DESCRIPTION
This option will disable daytime check, when myrmex is picking up resin. This can be used in modpacks like ATM6 where ís the dimension The Other, and there is always night, that means the myrmex will never pickup the resin.