### PR TITLE
Fix unnecessary EntityMetadata updates for under water stone statues

### DIFF
--- a/src/main/java/com/github/alexthe666/iceandfire/entity/EntityStoneStatue.java
+++ b/src/main/java/com/github/alexthe666/iceandfire/entity/EntityStoneStatue.java
@@ -237,6 +237,11 @@ public class EntityStoneStatue extends LivingEntity implements IBlacklistedFromS
 
 
     @Override
+    public boolean canBreatheUnderwater() {
+        return true;
+    }
+
+    @Override
     public boolean canBeTurnedToStone() {
         return false;
     }


### PR DESCRIPTION
This PR makes the game skip the under water breathing code for stone statues to fix a performance issue.

The issue is when stone entities are under water, their air (breath) metadata gets updated every tick. This is unnecessary because stone entities cannot drown.
This issue causes network lag when there are dozens of stone statues under water due to SEntityMetadata packet spam. 
it happened for me when a Gorgon decided to turn every nearby mob to stone including those that were inside water.

Before fix: receiving about 5000 packets per second 
After fix: receiving less than 800 packets per second 

