### PR TITLE
Fix stage 1 dragons teleports when put down. #4718

### DIFF
--- a/src/main/java/com/github/alexthe666/iceandfire/entity/EntityDragonBase.java
+++ b/src/main/java/com/github/alexthe666/iceandfire/entity/EntityDragonBase.java
@@ -1999,7 +1999,7 @@ public abstract class EntityDragonBase extends TameableEntity implements IPassab
 
     @Override
     public boolean isMovementBlocked() {
-        return this.getHealth() <= 0.0F || isQueuedToSit() && !this.isBeingRidden() || this.isModelDead();
+        return this.getHealth() <= 0.0F || isQueuedToSit() && !this.isBeingRidden() || this.isModelDead() || this.isPassenger();
     }
 
     @Override


### PR DESCRIPTION
By making dragons on shoulder movement blocked will disable their AI and navigator and fix the teleport issue.