### PR TITLE
Fix lightning dragon won't wakeup and AI related issue

### DIFF
--- a/src/main/java/com/github/alexthe666/iceandfire/entity/EntityLightningDragon.java
+++ b/src/main/java/com/github/alexthe666/iceandfire/entity/EntityLightningDragon.java
@@ -103,7 +103,7 @@ public class EntityLightningDragon extends EntityDragonBase {
 
     @Override
     public boolean isTimeToWake() {
-        return !this.world.isDaytime();
+        return !this.world.isDaytime() || this.getCommand() == 2;
     }
 
     @Override

--- a/src/main/java/com/github/alexthe666/iceandfire/entity/ai/DragonAIEscort.java
+++ b/src/main/java/com/github/alexthe666/iceandfire/entity/ai/DragonAIEscort.java
@@ -47,7 +47,7 @@ public class DragonAIEscort extends Goal {
 
     @Override
     public boolean shouldContinueExecuting() {
-        return this.dragon.canMove() && this.dragon.getAttackTarget() == null && this.dragon.getOwner() != null && this.dragon.getOwner().isAlive() && (this.dragon.getDistance(this.dragon.getOwner()) > 15 || !this.dragon.getNavigator().noPath());
+        return this.dragon.getCommand() == 2 && this.dragon.canMove() && this.dragon.getAttackTarget() == null && this.dragon.getOwner() != null && this.dragon.getOwner().isAlive() && (this.dragon.getDistance(this.dragon.getOwner()) > 15 || !this.dragon.getNavigator().noPath());
     }
 
 }

--- a/src/main/java/com/github/alexthe666/iceandfire/entity/ai/DragonAILookIdle.java
+++ b/src/main/java/com/github/alexthe666/iceandfire/entity/ai/DragonAILookIdle.java
@@ -28,7 +28,7 @@ public class DragonAILookIdle extends Goal {
 
     @Override
     public boolean shouldContinueExecuting() {
-        return this.idleTime >= 0;
+        return this.idleTime >= 0 && this.dragon.canMove();
     }
 
     @Override

--- a/src/main/java/com/github/alexthe666/iceandfire/entity/ai/DragonAIWatchClosest.java
+++ b/src/main/java/com/github/alexthe666/iceandfire/entity/ai/DragonAIWatchClosest.java
@@ -19,4 +19,12 @@ public class DragonAIWatchClosest extends LookAtGoal {
         }
         return super.shouldExecute();
     }
+
+    @Override
+    public boolean shouldContinueExecuting() {
+        if (this.entity instanceof EntityDragonBase && !((EntityDragonBase) this.entity).canMove()) {
+            return false;
+        }
+        return super.shouldContinueExecuting();
+    }
 }


### PR DESCRIPTION
This fixes
Lightning dragons won't wakeup at day when command is set to escort
Sleeping dragons sometimes turn their head
When you dismount a sitting dragon (command == 1) her head might turn to a different direction
Escort AI is not interrupted until the escort pos is reached, even if the command is no longer escort