### PR TITLE
Quick fix for dragons going backwards in flight

### DIFF
--- a/src/main/java/com/github/alexthe666/iceandfire/entity/ai/DragonAIRide.java
+++ b/src/main/java/com/github/alexthe666/iceandfire/entity/ai/DragonAIRide.java
@@ -71,6 +71,11 @@ public class DragonAIRide<T extends Mob & IFlyingMount> extends Goal {
         dragon.getMoveControl().setWantedPosition(x, y, z, speed);
     }
 
+    @Override
+    public boolean requiresUpdateEveryTick() {
+        return true;
+    }
+
     private boolean hovering() {
         return dragon.isHovering() || dragon instanceof EntityDragonBase && ((EntityDragonBase) dragon).useFlyingPathFinder();
     }


### PR DESCRIPTION
This is the temporary fix for dragons swim backwards mentioned in #4800. Actually I've encounted this issue in air flight as well when I was manipulating some move controller codes. I thought this was my own problem utill I saw #4800. 
By the way,
https://github.com/AlexModGuy/Ice_and_Fire/blob/f7fe4e286e3ff324d739f24b913b93e7a73fcca5/src/main/java/com/github/alexthe666/iceandfire/entity/IafDragonFlightManager.java#L302
for the flying friction stuff, it's somewhat similar to the vanilla horses in earlier version of mc (1.8? I can't remember) especially flying towards chunks that has not been generated. I believe mojang fixed it by letting the client to do the `motion` stuff and only tells the server about the position of the horses. One evidence is that if you look into the server thread when you riding a horse, its `motion` (or `deltaMovement` for mojmap) is actually `(0,0,0)`
I'm doing something to try implement that idea but I'm not sure if it'll work. (There're so many codes in dragon logic and flight mgr waiting me to understand :( and I'm not sure if they affect the problem as well)