### PR TITLE
Dragon ride redone

### DIFF
--- a/src/main/java/com/github/alexthe666/iceandfire/entity/EntityDragonBase.java
+++ b/src/main/java/com/github/alexthe666/iceandfire/entity/EntityDragonBase.java
@@ -293,7 +293,7 @@ public abstract class EntityDragonBase extends TamableAnimal implements IPassabi
 
     @Override
     protected void registerGoals() {
-        this.goalSelector.addGoal(0, new DragonAIRide<>(this));
+//        this.goalSelector.addGoal(0, new DragonAIRide<>(this));
         this.goalSelector.addGoal(1, new SitWhenOrderedToGoal(this));
         this.goalSelector.addGoal(2, new DragonAIMate(this, 1.0D));
         this.goalSelector.addGoal(3, new DragonAIReturnToRoost(this, 1.0D));
@@ -1013,7 +1013,7 @@ public abstract class EntityDragonBase extends TamableAnimal implements IPassabi
     }
 
     public boolean useFlyingPathFinder() {
-        return isFlying();
+        return isFlying() && this.getControllingPassenger() == null;
     }
 
     public void setGender(boolean male) {
@@ -1751,7 +1751,7 @@ public abstract class EntityDragonBase extends TamableAnimal implements IPassabi
         }
         level.getProfiler().pop();
         level.getProfiler().push("dragonFlight");
-        if (useFlyingPathFinder() && !level.isClientSide) {
+        if (isControlledByLocalInstance() && useFlyingPathFinder() && !level.isClientSide) {
             this.flightManager.update();
         }
         level.getProfiler().pop();

--- a/src/main/java/com/github/alexthe666/iceandfire/entity/EntityDragonBase.java
+++ b/src/main/java/com/github/alexthe666/iceandfire/entity/EntityDragonBase.java
@@ -2613,6 +2613,8 @@ public abstract class EntityDragonBase extends TamableAnimal implements IPassabi
         return 0.00336283f*Mth.square(getRenderSize()) + 0.1934242516f*getRenderSize() + -0.02622133882f;
     }
 
+    // For slowly raise rider position
+    protected float riderWalkingExtraY = 0;
     public Vec3 getRiderPosition() {
         // The old position is seems to be given by a series compute of magic numbers
         // So I replace the number with an even more magical yet better one I tuned
@@ -2652,9 +2654,12 @@ public abstract class EntityDragonBase extends TamableAnimal implements IPassabi
             } else {
                 // Extra height when walking, reduces model clipping
                 if (rider.zza > 0) {
-                    extraY += 1.1f * linearFactor;
-                    extraY += getRideHeightBase() * 0.1f;
+                    final float MAX_RAISE_HEIGHT = 1.1f * linearFactor + getRideHeightBase() * 0.1f;
+                    riderWalkingExtraY = Math.min(MAX_RAISE_HEIGHT, riderWalkingExtraY + 0.1f);
+                } else {
+                    riderWalkingExtraY = Math.max(0, riderWalkingExtraY - 0.15f);
                 }
+                extraY += riderWalkingExtraY;
             }
         }
 

--- a/src/main/java/com/github/alexthe666/iceandfire/entity/EntityDragonBase.java
+++ b/src/main/java/com/github/alexthe666/iceandfire/entity/EntityDragonBase.java
@@ -1720,13 +1720,18 @@ public abstract class EntityDragonBase extends TamableAnimal implements IPassabi
     }
 
     @Override
+    public float getStepHeight() {
+        return Math.max(1.2F, 1.2F + (Math.min(this.getAgeInDays(), 125) - 25) * 1.8F / 100F);
+    }
+
+    @Override
     public void tick() {
         super.tick();
         refreshDimensions();
         updateParts();
         this.prevDragonPitch = getDragonPitch();
         level.getProfiler().push("dragonLogic");
-        this.maxUpStep = 1.2F;
+        this.maxUpStep = getStepHeight();
         isOverAir = isOverAirLogic();
         logic.updateDragonCommon();
         if (this.isModelDead()) {

--- a/src/main/java/com/github/alexthe666/iceandfire/entity/EntityDragonBase.java
+++ b/src/main/java/com/github/alexthe666/iceandfire/entity/EntityDragonBase.java
@@ -2013,6 +2013,10 @@ public abstract class EntityDragonBase extends TamableAnimal implements IPassabi
         return this.getHealth() <= 0.0F || isOrderedToSit() && !this.isVehicle() || this.isModelDead() || this.isPassenger();
     }
 
+    @Override
+    public boolean isInWater() {
+        return super.isInWater() && this.getFluidHeight(FluidTags.WATER) > Mth.floor(this.getDragonStage() / 2.0f);
+    }
 
     public boolean allowLocalMotionControl = true;
     public boolean allowMousePitchControl = true;
@@ -2030,6 +2034,7 @@ public abstract class EntityDragonBase extends TamableAnimal implements IPassabi
         // Player riding controls
         // Note: when motion is handled by the client no server side setDeltaMovement() should be called
         // otherwise the movement will halt
+        // Todo: move wrongly fix
         if (allowLocalMotionControl && this.getControllingPassenger() != null && canBeControlledByRider()) {
             LivingEntity rider = (LivingEntity) this.getControllingPassenger();
             if (rider == null) {
@@ -2044,7 +2049,7 @@ public abstract class EntityDragonBase extends TamableAnimal implements IPassabi
                 double vertical = 0;
                 float speed = (float) this.getAttributeValue(Attributes.MOVEMENT_SPEED);
                 // Bigger difference in speed for young and elder dragons
-                // Todo: use age in days for quicker compute?
+//                float airSpeedModifier = (float) (5.2f + 1.0f * Mth.map(Math.min(this.getAgeInDays(), 125), 0, 125, 0f, 1.5f));
                 float airSpeedModifier = (float) (5.2f + 1.0f * Mth.map(speed, this.minimumSpeed, this.maximumSpeed, 0f, 1.5f));
                 // Apply speed mod
                 speed *= airSpeedModifier;
@@ -2135,7 +2140,7 @@ public abstract class EntityDragonBase extends TamableAnimal implements IPassabi
                 this.updatePitch(this.yOld - this.getY());
                 return;
             }
-            // In water move control, for those that can't
+            // In water move control, for those that can't swim
             else if (isInWater() || isInLava()) {
                 double forward = rider.zza;
                 double strafing = rider.xxa;

--- a/src/main/java/com/github/alexthe666/iceandfire/entity/EntityDragonBase.java
+++ b/src/main/java/com/github/alexthe666/iceandfire/entity/EntityDragonBase.java
@@ -2149,9 +2149,15 @@ public abstract class EntityDragonBase extends TamableAnimal implements IPassabi
                 }
 
                 this.flyingSpeed = speed;
+                // Float in water for those can't swim is done in LivingEntity#aiStep on server side
+                // Leave this handled by both side before we have a better solution
                 this.setSpeed(speed);
+                // Overwrite the zza in setSpeed
+                this.setZza((float) forward);
                 // Vanilla in water behavior includes float on water and moving very slow
+                // in lava behavior includes moving slow and sink
                 super.travel(pTravelVector.add(strafing, vertical, forward));
+
                 return;
             }
             // Walking control

--- a/src/main/java/com/github/alexthe666/iceandfire/entity/EntityDragonBase.java
+++ b/src/main/java/com/github/alexthe666/iceandfire/entity/EntityDragonBase.java
@@ -1753,7 +1753,7 @@ public abstract class EntityDragonBase extends TamableAnimal implements IPassabi
         }
         level.getProfiler().pop();
         level.getProfiler().push("dragonFlight");
-        if (useFlyingPathFinder() && !level.isClientSide) {
+        if (useFlyingPathFinder() && !level.isClientSide && isControlledByLocalInstance()) {
             this.flightManager.update();
         }
         level.getProfiler().pop();
@@ -2276,7 +2276,7 @@ public abstract class EntityDragonBase extends TamableAnimal implements IPassabi
                     this.setHovering(true);
                 }
                 // Hitting terrain with big angle of attack
-                if (this.isFlying() && rider.getXRot() > 10 && !this.isOverAir()) {
+                if (!this.isOverAir() && this.isFlying() && rider.getXRot() > 10 && !this.isInWater()) {
                     this.setHovering(false);
                     this.setFlying(false);
                 }

--- a/src/main/java/com/github/alexthe666/iceandfire/entity/EntityDragonBase.java
+++ b/src/main/java/com/github/alexthe666/iceandfire/entity/EntityDragonBase.java
@@ -2620,6 +2620,11 @@ public abstract class EntityDragonBase extends TamableAnimal implements IPassabi
     }
 
     @Override
+    public Vec3 getDismountLocationForPassenger(LivingEntity pPassenger) {
+        return this.getRiderPosition().add(0, pPassenger.getBbHeight(), 0);
+    }
+
+    @Override
     public void kill() {
         this.remove(RemovalReason.KILLED);
         this.setDeathStage(this.getAgeInDays() / 5);

--- a/src/main/java/com/github/alexthe666/iceandfire/entity/EntityDragonBase.java
+++ b/src/main/java/com/github/alexthe666/iceandfire/entity/EntityDragonBase.java
@@ -2434,6 +2434,12 @@ public abstract class EntityDragonBase extends TamableAnimal implements IPassabi
             // this sometimes will cause movement check to fail when the vehicle Y position is an integer and is approaching a stair
             // resulting the move wrongly message in server console when going upstairs and stuck movements
             if (isControlledByLocalInstance()) {
+                // This is how EntityDragonBase#breakBlock handles movement when breaking blocks
+                // it's done by server, however client does not fire server side events, so breakBlock() here won't work
+                // slow down all movement when collided is simpler
+                if (horizontalCollision) {
+                    this.setDeltaMovement(this.getDeltaMovement().multiply(0.6F, 1, 0.6F));
+                }
                 super.move(pType, pPos);
             } else {
                 // compensation especially for the move call in server side

--- a/src/main/java/com/github/alexthe666/iceandfire/entity/EntityDragonBase.java
+++ b/src/main/java/com/github/alexthe666/iceandfire/entity/EntityDragonBase.java
@@ -2445,6 +2445,13 @@ public abstract class EntityDragonBase extends TamableAnimal implements IPassabi
                 // compensation especially for the move call in server side
                 super.move(pType, pPos.add(0, 1.0E-6D, 0));
             }
+            // Set no gravity flag to prevent getting kicked by flight disabled servers
+            if (this.isHovering() || this.isFlying()) {
+                this.setNoGravity(true);
+            } else {
+                this.setNoGravity(false);
+            }
+
         } else {
             super.move(pType, pPos);
         }

--- a/src/main/java/com/github/alexthe666/iceandfire/entity/EntityDragonBase.java
+++ b/src/main/java/com/github/alexthe666/iceandfire/entity/EntityDragonBase.java
@@ -2258,13 +2258,13 @@ public abstract class EntityDragonBase extends TamableAnimal implements IPassabi
      * Updates when rider is onboard
      */
     public void updateRider() {
-        this.ticksStill = 0;
-        this.hoverTicks = 0;
-        this.flyTicks = 0;
-
         Entity controllingPassenger = this.getControllingPassenger();
 
         if (controllingPassenger instanceof Player rider) {
+            this.ticksStill = 0;
+            this.hoverTicks = 0;
+            this.flyTicks = 0;
+
             if (this.isGoingUp()) {
                 if (!this.isFlying() && !this.isHovering()) {
                     // Update spacebar tick for take off
@@ -2471,6 +2471,8 @@ public abstract class EntityDragonBase extends TamableAnimal implements IPassabi
             }
 
         } else {
+            // The flight mgr is not ready for noGravity
+            this.setNoGravity(false);
             super.move(pType, pPos);
         }
 

--- a/src/main/java/com/github/alexthe666/iceandfire/entity/EntityFireDragon.java
+++ b/src/main/java/com/github/alexthe666/iceandfire/entity/EntityFireDragon.java
@@ -272,6 +272,7 @@ public class EntityFireDragon extends EntityDragonBase {
     @Override
     public void travel(@NotNull Vec3 pTravelVector) {
         if (this.isInLava()) {
+            // In lava special
             if (this.isEffectiveAi() && this.getControllingPassenger() == null) {
                 // Ice dragons swim faster
                 this.moveRelative(this.getSpeed(), pTravelVector);
@@ -327,7 +328,10 @@ public class EntityFireDragon extends EntityDragonBase {
             } else {
                 super.travel(pTravelVector);
             }
-        } else if (this.level.getBlockState(this.getBlockPosBelowThatAffectsMyMovement()).getFluidState().is(FluidTags.LAVA)) {
+        }
+        // Not in lava special
+        else if (allowLocalMotionControl && this.getControllingPassenger() != null && canBeControlledByRider() && !isHovering() && !isFlying()
+                && this.level.getBlockState(this.getBlockPosBelowThatAffectsMyMovement()).getFluidState().is(FluidTags.LAVA)) {
             LivingEntity rider = (LivingEntity) this.getControllingPassenger();
 
             double forward = rider.zza;
@@ -357,7 +361,7 @@ public class EntityFireDragon extends EntityDragonBase {
                 this.setDeltaMovement(Vec3.ZERO);
             }
             this.tryCheckInsideBlocks();
-            this.updatePitch(this.yOld - this.getY());
+//            this.updatePitch(this.yOld - this.getY());
             return;
         } else {
             super.travel(pTravelVector);

--- a/src/main/java/com/github/alexthe666/iceandfire/entity/EntityFireDragon.java
+++ b/src/main/java/com/github/alexthe666/iceandfire/entity/EntityFireDragon.java
@@ -316,9 +316,6 @@ public class EntityFireDragon extends EntityDragonBase {
                         currentMotion = new Vec3(currentMotion.x, 0.2D, currentMotion.z);
                     }
                     this.setDeltaMovement(currentMotion.scale(0.7D));
-                    if (this.getTarget() == null) {
-//                    this.setDeltaMovement(this.getDeltaMovement().add(0.0D, -0.005D, 0.0D));
-                    }
 
                     this.calculateEntityAnimation(this, false);
                 } else {
@@ -329,7 +326,7 @@ public class EntityFireDragon extends EntityDragonBase {
                 super.travel(pTravelVector);
             }
         }
-        // Not in lava special
+        // Over lava special
         else if (allowLocalMotionControl && this.getControllingPassenger() != null && canBeControlledByRider() && !isHovering() && !isFlying()
                 && this.level.getBlockState(this.getBlockPosBelowThatAffectsMyMovement()).getFluidState().is(FluidTags.LAVA)) {
             LivingEntity rider = (LivingEntity) this.getControllingPassenger();
@@ -343,7 +340,7 @@ public class EntityFireDragon extends EntityDragonBase {
             float groundSpeedModifier = (float) (1.8F * this.getFlightSpeedModifier());
             speed *= groundSpeedModifier;
             // Try to match the original riding speed
-            forward *= speed;
+//            forward *= speed;
             // Faster sprint
             forward *= rider.isSprinting() ? 1.2f : 1.0f;
             // Slower going back
@@ -357,6 +354,12 @@ public class EntityFireDragon extends EntityDragonBase {
 
                 // Vanilla walking behavior includes going up steps
                 super.travel(new Vec3(strafing, vertical, forward));
+
+                Vec3 currentMotion = this.getDeltaMovement();
+                if (this.horizontalCollision) {
+                    currentMotion = new Vec3(currentMotion.x, 0.2D, currentMotion.z);
+                }
+                this.setDeltaMovement(currentMotion.scale(0.7D));
             } else {
                 this.setDeltaMovement(Vec3.ZERO);
             }

--- a/src/main/java/com/github/alexthe666/iceandfire/entity/EntityIceDragon.java
+++ b/src/main/java/com/github/alexthe666/iceandfire/entity/EntityIceDragon.java
@@ -248,9 +248,8 @@ public class EntityIceDragon extends EntityDragonBase {
                 this.setSwimming(false);
             }
         }
-        if (!level.isClientSide && (this.isHovering() && !this.isFlying() && (this.isInMaterialWater() || this.isOverWater()))) {
+        if (!level.isClientSide && this.getControllingPassenger() == null && (this.isHovering() && !this.isFlying() && (this.isInMaterialWater() || this.isOverWater()))) {
             this.setDeltaMovement(this.getDeltaMovement().add(0.0D, 0.2D, 0.0D));
-
         }
         if (swimCycle < 48) {
             swimCycle += 2;
@@ -667,7 +666,7 @@ public class EntityIceDragon extends EntityDragonBase {
 
     @Override
     public boolean useFlyingPathFinder() {
-        return this.isFlying() || this.isInMaterialWater();
+        return (this.isFlying() || this.isInMaterialWater()) && this.getControllingPassenger() == null;
     }
 
     @Override

--- a/src/main/java/com/github/alexthe666/iceandfire/entity/EntityIceDragon.java
+++ b/src/main/java/com/github/alexthe666/iceandfire/entity/EntityIceDragon.java
@@ -341,6 +341,7 @@ public class EntityIceDragon extends EntityDragonBase {
     @Override
     public void travel(Vec3 pTravelVector) {
         if (this.isInWater()) {
+            // In water special
             if (this.isEffectiveAi() && this.getControllingPassenger() == null) {
                 // Ice dragons swim faster
                 this.moveRelative(this.getSpeed(), pTravelVector);
@@ -398,7 +399,10 @@ public class EntityIceDragon extends EntityDragonBase {
                 super.travel(pTravelVector);
             }
 
-        } else if (this.level.getBlockState(this.getBlockPosBelowThatAffectsMyMovement()).getFluidState().is(FluidTags.WATER)) {
+        }
+        // Not in water special
+        else if (allowLocalMotionControl && this.getControllingPassenger() != null && canBeControlledByRider() && !isHovering() && !isFlying()
+                && this.level.getBlockState(this.getBlockPosBelowThatAffectsMyMovement()).getFluidState().is(FluidTags.WATER)) {
             // Movement when walking on the water, mainly used for not slowing down when jumping out of water
             // Todo: the water and ashore part is still messy
             LivingEntity rider = (LivingEntity) this.getControllingPassenger();
@@ -430,7 +434,7 @@ public class EntityIceDragon extends EntityDragonBase {
                 this.setDeltaMovement(Vec3.ZERO);
             }
             this.tryCheckInsideBlocks();
-            this.updatePitch(this.yOld - this.getY());
+//            this.updatePitch(this.yOld - this.getY());
             return;
         } else {
             super.travel(pTravelVector);

--- a/src/main/java/com/github/alexthe666/iceandfire/entity/EntityIceDragon.java
+++ b/src/main/java/com/github/alexthe666/iceandfire/entity/EntityIceDragon.java
@@ -16,12 +16,15 @@ import net.minecraft.nbt.CompoundTag;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.sounds.SoundEvent;
 import net.minecraft.sounds.SoundEvents;
+import net.minecraft.tags.FluidTags;
+import net.minecraft.tags.TagKey;
 import net.minecraft.util.Mth;
 import net.minecraft.world.damagesource.DamageSource;
 import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.EntityType;
 import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.entity.MoverType;
+import net.minecraft.world.entity.ai.attributes.Attributes;
 import net.minecraft.world.entity.animal.WaterAnimal;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.Item;
@@ -30,6 +33,7 @@ import net.minecraft.world.level.ClipContext;
 import net.minecraft.world.level.ItemLike;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.LevelReader;
+import net.minecraft.world.level.material.Fluid;
 import net.minecraft.world.phys.HitResult;
 import net.minecraft.world.phys.Vec3;
 import net.minecraftforge.common.MinecraftForge;
@@ -320,19 +324,54 @@ public class EntityIceDragon extends EntityDragonBase {
     }
 
     @Override
-    public void travel(Vec3 travelVector) {
-        if (this.isEffectiveAi() && this.isInWater()) {
-            this.moveRelative(this.getSpeed(), travelVector);
-            this.move(MoverType.SELF, this.getDeltaMovement());
-            this.setDeltaMovement(this.getDeltaMovement().scale(0.9D));
-            if (this.getTarget() == null) {
-                this.setDeltaMovement(this.getDeltaMovement().add(0.0D, -0.005D, 0.0D));
+    public void travel(Vec3 pTravelVector) {
+        if (this.isInWater() || this.level.getBlockState(this.getBlockPosBelowThatAffectsMyMovement()).getFluidState().is(FluidTags.WATER)) {
+            if (this.isEffectiveAi() && this.getControllingPassenger() == null) {
+                // Ice dragons swim faster
+                this.moveRelative(this.getSpeed(), pTravelVector);
+                this.move(MoverType.SELF, this.getDeltaMovement());
+                this.setDeltaMovement(this.getDeltaMovement().scale(0.9D));
+                if (this.getTarget() == null) {
+                    this.setDeltaMovement(this.getDeltaMovement().add(0.0D, -0.005D, 0.0D));
+                }
+            } else if (allowLocalMotionControl && this.getControllingPassenger() != null && canBeControlledByRider() && !isHovering() && !isFlying()) {
+                LivingEntity rider = (LivingEntity) this.getControllingPassenger();
+
+                Vec3 travelVector = new Vec3(
+                        rider.xxa,
+                        isGoingUp() ? 1.0d :
+                                isGoingDown() ? -1.0d : 0,
+                        rider.zza
+                );
+                float speed = (float) this.getAttributeValue(Attributes.MOVEMENT_SPEED) * 0.3f;
+                this.setSpeed(speed);
+
+                if (this.isControlledByLocalInstance()) {
+                    this.moveRelative(this.getSpeed(), travelVector);
+                    this.move(MoverType.SELF, this.getDeltaMovement());
+
+                    Vec3 currentMotion = this.getDeltaMovement();
+                    if (this.horizontalCollision) {
+                        currentMotion = new Vec3(currentMotion.x, 0.2D, currentMotion.z);
+                    }
+                    this.setDeltaMovement(currentMotion.scale(0.9D));
+                    if (this.getTarget() == null) {
+//                    this.setDeltaMovement(this.getDeltaMovement().add(0.0D, -0.005D, 0.0D));
+                    }
+
+                    this.calculateEntityAnimation(this, false);
+                } else {
+                    this.setDeltaMovement(Vec3.ZERO);
+                }
+                this.tryCheckInsideBlocks();
+            } else {
+                super.travel(pTravelVector);
             }
+
         } else {
-            super.travel(travelVector);
+            super.travel(pTravelVector);
         }
     }
-
 
     @Override
     public ResourceLocation getDeadLootTable() {

--- a/src/main/java/com/github/alexthe666/iceandfire/entity/EntityIceDragon.java
+++ b/src/main/java/com/github/alexthe666/iceandfire/entity/EntityIceDragon.java
@@ -324,6 +324,22 @@ public class EntityIceDragon extends EntityDragonBase {
     }
 
     @Override
+    public void onInsideBubbleColumn(boolean pDownwards) {
+        // Disable bubble column drag for elder dragons
+        if (this.getDragonStage() < 2) {
+            super.onInsideBubbleColumn(pDownwards);
+        }
+    }
+
+    @Override
+    public void onAboveBubbleCol(boolean pDownwards) {
+        // Disable bubble column drag for elder dragons
+        if (this.getDragonStage() < 2) {
+            super.onInsideBubbleColumn(pDownwards);
+        }
+    }
+
+    @Override
     public void travel(Vec3 pTravelVector) {
         if (this.isInWater() || this.level.getBlockState(this.getBlockPosBelowThatAffectsMyMovement()).getFluidState().is(FluidTags.WATER)) {
             if (this.isEffectiveAi() && this.getControllingPassenger() == null) {
@@ -332,21 +348,35 @@ public class EntityIceDragon extends EntityDragonBase {
                 this.move(MoverType.SELF, this.getDeltaMovement());
                 this.setDeltaMovement(this.getDeltaMovement().scale(0.9D));
                 if (this.getTarget() == null) {
-                    this.setDeltaMovement(this.getDeltaMovement().add(0.0D, -0.005D, 0.0D));
+//                    this.setDeltaMovement(this.getDeltaMovement().add(0.0D, -0.005D, 0.0D));
                 }
             } else if (allowLocalMotionControl && this.getControllingPassenger() != null && canBeControlledByRider() && !isHovering() && !isFlying()) {
                 LivingEntity rider = (LivingEntity) this.getControllingPassenger();
 
+                float speed = (float) this.getAttributeValue(Attributes.MOVEMENT_SPEED);
+                // Bigger difference in speed for young and elder dragons
+                float waterSpeedMod =  (float) (0.42f + 0.1 * Mth.map(speed, this.minimumSpeed, this.maximumSpeed, 0f, 1.5f));
+                speed *= waterSpeedMod;
+                speed *= rider.isSprinting() ? 1.5f : 1.0f;
+
+                float vertical = 0f;
+                if (isGoingUp() && !isGoingDown()) {
+                    vertical = 1f;
+                } else if (isGoingDown() && !isGoingUp()) {
+                    vertical = -1f;
+                } else if (isGoingUp() && isGoingDown() && isControlledByLocalInstance()) {
+                    // Try floating
+                    this.setDeltaMovement(this.getDeltaMovement().multiply(1.0f, 0.5f, 1.0f));
+                }
+
                 Vec3 travelVector = new Vec3(
                         rider.xxa,
-                        isGoingUp() ? 1.0d :
-                                isGoingDown() ? -1.0d : 0,
+                        vertical,
                         rider.zza
                 );
-                float speed = (float) this.getAttributeValue(Attributes.MOVEMENT_SPEED) * 0.3f;
-                this.setSpeed(speed);
-
                 if (this.isControlledByLocalInstance()) {
+                    this.setSpeed(speed);
+
                     this.moveRelative(this.getSpeed(), travelVector);
                     this.move(MoverType.SELF, this.getDeltaMovement());
 

--- a/src/main/java/com/github/alexthe666/iceandfire/entity/EntityIceDragon.java
+++ b/src/main/java/com/github/alexthe666/iceandfire/entity/EntityIceDragon.java
@@ -381,14 +381,10 @@ public class EntityIceDragon extends EntityDragonBase {
                     this.move(MoverType.SELF, this.getDeltaMovement());
 
                     Vec3 currentMotion = this.getDeltaMovement();
-                    // Todo: when the y coordinate is an integer there's a chance of getting the moved wrongly error and stuck
                     if (this.horizontalCollision) {
                         currentMotion = new Vec3(currentMotion.x, 0.2D, currentMotion.z);
                     }
                     this.setDeltaMovement(currentMotion.scale(0.9D));
-                    if (this.getTarget() == null) {
-//                    this.setDeltaMovement(this.getDeltaMovement().add(0.0D, -0.005D, 0.0D));
-                    }
 
                     this.calculateEntityAnimation(this, false);
                 } else {
@@ -400,11 +396,10 @@ public class EntityIceDragon extends EntityDragonBase {
             }
 
         }
-        // Not in water special
+        // Over water special
         else if (allowLocalMotionControl && this.getControllingPassenger() != null && canBeControlledByRider() && !isHovering() && !isFlying()
                 && this.level.getBlockState(this.getBlockPosBelowThatAffectsMyMovement()).getFluidState().is(FluidTags.WATER)) {
             // Movement when walking on the water, mainly used for not slowing down when jumping out of water
-            // Todo: the water and ashore part is still messy
             LivingEntity rider = (LivingEntity) this.getControllingPassenger();
 
             double forward = rider.zza;
@@ -416,7 +411,7 @@ public class EntityIceDragon extends EntityDragonBase {
             float groundSpeedModifier = (float) (1.8F * this.getFlightSpeedModifier());
             speed *= groundSpeedModifier;
             // Try to match the original riding speed
-            forward *= speed;
+//            forward *= speed;
             // Faster sprint
             forward *= rider.isSprinting() ? 1.2f : 1.0f;
             // Slower going back
@@ -430,6 +425,12 @@ public class EntityIceDragon extends EntityDragonBase {
 
                 // Vanilla walking behavior includes going up steps
                 super.travel(new Vec3(strafing, vertical, forward));
+
+                Vec3 currentMotion = this.getDeltaMovement();
+                if (this.horizontalCollision) {
+                    currentMotion = new Vec3(currentMotion.x, 0.2D, currentMotion.z);
+                }
+                this.setDeltaMovement(currentMotion.scale(1.0D));
             } else {
                 this.setDeltaMovement(Vec3.ZERO);
             }

--- a/src/main/java/com/github/alexthe666/iceandfire/entity/EntityIceDragon.java
+++ b/src/main/java/com/github/alexthe666/iceandfire/entity/EntityIceDragon.java
@@ -334,7 +334,7 @@ public class EntityIceDragon extends EntityDragonBase {
     public void onAboveBubbleCol(boolean pDownwards) {
         // Disable bubble column drag for elder dragons
         if (this.getDragonStage() < 2) {
-            super.onInsideBubbleColumn(pDownwards);
+            super.onAboveBubbleCol(pDownwards);
         }
     }
 

--- a/src/main/java/com/github/alexthe666/iceandfire/entity/IafDragonFlightManager.java
+++ b/src/main/java/com/github/alexthe666/iceandfire/entity/IafDragonFlightManager.java
@@ -299,7 +299,12 @@ public class IafDragonFlightManager {
 
         @Override
         public void tick() {
-            //FIXME: Dragon movement needs to be completely redone to account for weird friction stuff
+            if (dragon instanceof EntityDragonBase theDragon && theDragon.getControllingPassenger() != null) {
+                // New ride system doesn't need move controller
+                // The flight move control is disabled here, the walking move controller will stay Operation.WAIT so nothing will happen too
+                return;
+            }
+
             double flySpeed = speedModifier * speedMod() * 3;
             Vec3 dragonVec = dragon.position();
             Vec3 moveVec = new Vec3(wantedX, wantedY, wantedZ);

--- a/src/main/java/com/github/alexthe666/iceandfire/event/ClientEvents.java
+++ b/src/main/java/com/github/alexthe666/iceandfire/event/ClientEvents.java
@@ -188,18 +188,24 @@ public class ClientEvents {
         }
     }
 
+    // TODO: add this to client side config
+    public final boolean AUTO_ADAPT_3RD_PERSON = true;
     @SubscribeEvent
     public void onEntityMount(EntityMountEvent event) {
-        if (IafConfig.dragonAuto3rdPerson) {
-            if (event.getEntityBeingMounted() instanceof EntityDragonBase && event.getWorldObj().isClientSide && event.getEntityMounting() == Minecraft.getInstance().player) {
-                EntityDragonBase dragon = (EntityDragonBase) event.getEntityBeingMounted();
-                if (dragon.isTame() && dragon.isOwnedBy(Minecraft.getInstance().player)) {
+
+        if (event.getEntityBeingMounted() instanceof EntityDragonBase && event.getWorldObj().isClientSide && event.getEntityMounting() == Minecraft.getInstance().player) {
+            EntityDragonBase dragon = (EntityDragonBase) event.getEntityBeingMounted();
+            if (dragon.isTame() && dragon.isOwnedBy(Minecraft.getInstance().player)) {
+                if (AUTO_ADAPT_3RD_PERSON) {
+                    // Auto adjust 3rd person camera's according to dragon's size
+                    IceAndFire.PROXY.setDragon3rdPersonView(2);
+                }
+                if (IafConfig.dragonAuto3rdPerson) {
                     if (event.isDismounting()) {
                         Minecraft.getInstance().options.setCameraType(CameraType.values()[IceAndFire.PROXY.getPreviousViewType()]);
                     } else {
                         IceAndFire.PROXY.setPreviousViewType(Minecraft.getInstance().options.getCameraType().ordinal());
                         Minecraft.getInstance().options.setCameraType(CameraType.values()[1]);
-                        IceAndFire.PROXY.setDragon3rdPersonView(2);
                     }
                 }
             }

--- a/src/main/java/com/github/alexthe666/iceandfire/message/MessageDragonControl.java
+++ b/src/main/java/com/github/alexthe666/iceandfire/message/MessageDragonControl.java
@@ -74,7 +74,9 @@ public class MessageDragonControl {
                             if (dragon.isOwnedBy(player)) {
                                 dragon.setControlState(message.controlState);
                             }
-                            dragon.setPos(message.getPosX(), message.getPosY(), message.getPosZ());
+                            // The riding setPos is performed in Entity#move
+                            // Extra setPos will cause server side movement check to fail, resulting move wrongly msg
+//                            dragon.setPos(message.getPosX(), message.getPosY(), message.getPosZ());
                         } else if (entity instanceof EntityHippogryph) {
                             EntityHippogryph hippo = (EntityHippogryph) entity;
                             if (hippo.isOwnedBy(player)) {


### PR DESCRIPTION
This is not a bug fix, this is a dragon riding system redone. Mainly it smooth the ride by letting clients to do the motion stuff, just like how vanilla horses are doing. I tried to left everything else untouched but I haven't test it extensivly. So it might be buggy.
But if you're interested, here's what I've done so far:

- A completely redone over the dragon riding system ( for players to ride so far ), by the idea of how vanilla horses are done.
- Flying near the unloaded chunks are no longer laggy, no more weird friction in the air.
- Riding movement is now handled by the client, the server knows nothing about `deltaMovement` now.
- The old "AI+move controller" riding system is disabled for the dragons, but not deleted.
- Anything that tries to access `setDeltaMovement` on server side during the ride is disabled, such as the flight manager, since that will cause dragons to halt.
- Riding related stuff from `IafDragonLogic` is moved to `EntityDragonBase`
- Dragons can now move sideway and backward correctly. Sprint key has its uses now as well.
- Dragons now need time to accelerate, they don't reach their max speed instantly. This changes the feeling how the dragon is handled.
- Ice dragons goes faster in water, fire dragons goes faster in lava. Nothing for lightning dragons so far.
- Riders no longer dismount at dragon's feet, they will now positioned right where they are after dismount.
~~~
The following might affect AI controlled movement as well
~~~
- Elder dragons no longer slow down and swim in shallow water. This modified the `isInWater` method and will influence everything like the AI system and animation system. For bigger dragons doing this will prevent them from swimming in the air.
- Elder dragons have bigger step height, this means they can walk up higher blocks without jumping. The most direct effect is that dragons elder than 55 can walk over fences, though their pathfinder won't deliberately to do that.

Something else:

- Fire dragons no longer sink in lava
- Diving in air with attack button pressed will play tackling animation
- Ice dragons are now unaffected by bubble columns
- Fire dragons are now unaffected by the soul sand

Some idea not implemented:
- Free camera when riding. Not sure how to get hitboxes to their right position.

~~~
Some bug not yet fix
~~~
~~Rare move wrongly problem still exist. Mostly happens when going up hills diagonally~~
Move wrongly problem is fixed by disable the move wrongly check for dragons

I'm not sure if I'm doing this correct but I do believe a smooth ride is critical for our revolutionary dragon experience :), please let me know if I've done something wrong.

Anyway, happy flying.  飞的开心

FYI: Is fandom page still active? I noticed some info is different with what's in the code
