### PR TITLE
potion correctness for dragons

### DIFF
--- a/src/main/java/com/github/alexthe666/iceandfire/IceAndFire.java
+++ b/src/main/java/com/github/alexthe666/iceandfire/IceAndFire.java
@@ -205,6 +205,8 @@ public class IceAndFire {
         NETWORK_WRAPPER.registerMessage(packetsRegistered++, MessageSyncPath.class, MessageSyncPath::write, MessageSyncPath::read, MessageSyncPath.Handler::handle);
         NETWORK_WRAPPER.registerMessage(packetsRegistered++, MessageSyncPathReached.class, MessageSyncPathReached::write, MessageSyncPathReached::read, MessageSyncPathReached.Handler::handle);
         NETWORK_WRAPPER.registerMessage(packetsRegistered++, MessageSwingArm.class, MessageSwingArm::write, MessageSwingArm::read, MessageSwingArm.Handler::handle);
+        NETWORK_WRAPPER.registerMessage(packetsRegistered++, MessageSyncEffects.class, MessageSyncEffects::encoder, MessageSyncEffects::decoder, MessageSyncEffects::handler);
+
         event.enqueueWork(() -> {
             PROXY.setup();
             IafVillagerRegistry.setup();

--- a/src/main/java/com/github/alexthe666/iceandfire/client/gui/GuiDragon.java
+++ b/src/main/java/com/github/alexthe666/iceandfire/client/gui/GuiDragon.java
@@ -4,6 +4,7 @@ import com.github.alexthe666.iceandfire.IceAndFire;
 import com.github.alexthe666.iceandfire.client.StatCollector;
 import com.github.alexthe666.iceandfire.entity.EntityDragonBase;
 import com.github.alexthe666.iceandfire.inventory.ContainerDragon;
+import com.github.alexthe666.iceandfire.message.MessageSyncEffects;
 import com.mojang.blaze3d.systems.RenderSystem;
 import com.mojang.blaze3d.vertex.PoseStack;
 import net.minecraft.client.gui.Font;
@@ -33,6 +34,10 @@ public class GuiDragon extends EffectRenderingInventoryScreen<ContainerDragon> {
     public GuiDragon(ContainerDragon dragonInv, Inventory playerInv, Component name) {
         super(dragonInv, playerInv, name);
         this.imageHeight = 214;
+
+        if (IceAndFire.PROXY.getReferencedMob() instanceof LivingEntity livingEntity) {
+            IceAndFire.sendMSGToServer(new MessageSyncEffects(livingEntity));
+        }
     }
 
     @Override

--- a/src/main/java/com/github/alexthe666/iceandfire/entity/EntityDragonBase.java
+++ b/src/main/java/com/github/alexthe666/iceandfire/entity/EntityDragonBase.java
@@ -556,9 +556,6 @@ public abstract class EntityDragonBase extends TamableAnimal implements IPassabi
     public void openInventory(Player player) {
         if (!this.level.isClientSide)
             NetworkHooks.openGui((ServerPlayer) player, getMenuProvider());
-        else {
-            IceAndFire.sendMSGToServer(new MessageSyncEffects(this));
-        }
         IceAndFire.PROXY.setReferencedMob(this);
     }
 

--- a/src/main/java/com/github/alexthe666/iceandfire/entity/EntityDragonBase.java
+++ b/src/main/java/com/github/alexthe666/iceandfire/entity/EntityDragonBase.java
@@ -21,6 +21,7 @@ import com.github.alexthe666.iceandfire.item.ItemDragonArmor;
 import com.github.alexthe666.iceandfire.item.ItemSummoningCrystal;
 import com.github.alexthe666.iceandfire.message.MessageDragonSetBurnBlock;
 import com.github.alexthe666.iceandfire.message.MessageStartRidingMob;
+import com.github.alexthe666.iceandfire.message.MessageSyncEffects;
 import com.github.alexthe666.iceandfire.misc.IafSoundRegistry;
 import com.github.alexthe666.iceandfire.pathfinding.raycoms.AdvancedPathNavigate;
 import com.github.alexthe666.iceandfire.pathfinding.raycoms.IPassabilityNavigator;
@@ -555,6 +556,9 @@ public abstract class EntityDragonBase extends TamableAnimal implements IPassabi
     public void openInventory(Player player) {
         if (!this.level.isClientSide)
             NetworkHooks.openGui((ServerPlayer) player, getMenuProvider());
+        else {
+            IceAndFire.sendMSGToServer(new MessageSyncEffects(this));
+        }
         IceAndFire.PROXY.setReferencedMob(this);
     }
 

--- a/src/main/java/com/github/alexthe666/iceandfire/entity/EntityMutlipartPart.java
+++ b/src/main/java/com/github/alexthe666/iceandfire/entity/EntityMutlipartPart.java
@@ -281,4 +281,17 @@ public abstract class EntityMutlipartPart extends Entity {
     public boolean shouldContinuePersisting() {
         return isAddedToWorld() || this.isRemoved();
     }
+
+    public final int MAX_RECURSIVE_PARENT = 10;
+    @Nullable
+    public LivingEntity getRootParent() {
+        Entity rootParent = this.getParent();
+//        while ((rootParent instanceof EntityMutlipartPart)) {
+//            rootParent = ((EntityMutlipartPart) rootParent).getParent();
+//        }
+        for (int i = 0; i < MAX_RECURSIVE_PARENT && (rootParent instanceof EntityMutlipartPart); i++) {
+            rootParent = ((EntityMutlipartPart) rootParent).getParent();
+        }
+        return rootParent instanceof LivingEntity ? (LivingEntity) rootParent : null;
+    }
 }

--- a/src/main/java/com/github/alexthe666/iceandfire/message/MessageSyncEffects.java
+++ b/src/main/java/com/github/alexthe666/iceandfire/message/MessageSyncEffects.java
@@ -1,0 +1,89 @@
+package com.github.alexthe666.iceandfire.message;
+
+import com.github.alexthe666.iceandfire.IceAndFire;
+import net.minecraft.client.Minecraft;
+import net.minecraft.nbt.CompoundTag;
+import net.minecraft.network.FriendlyByteBuf;
+import net.minecraft.server.level.ServerPlayer;
+import net.minecraft.world.effect.MobEffectInstance;
+import net.minecraft.world.entity.Entity;
+import net.minecraft.world.entity.LivingEntity;
+import net.minecraftforge.network.NetworkDirection;
+import net.minecraftforge.network.NetworkEvent;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Iterator;
+import java.util.function.Supplier;
+
+public class MessageSyncEffects {
+    private int entityID;
+    private Collection<MobEffectInstance> effects;
+
+
+    /**
+     * Update the potion effects between server and client
+     * server transmit this msg to inform the client of the potion effects on an entity
+     * client transmit this msg to request an update on an entity
+     * @param dragon
+     */
+    public MessageSyncEffects(LivingEntity dragon) {
+        this.entityID = dragon.getId();
+        this.effects = dragon.getActiveEffects();
+    }
+
+    public MessageSyncEffects(int entityID, Collection<MobEffectInstance> effects) {
+        this.entityID = entityID;
+        this.effects = effects;
+    }
+
+
+    public static MessageSyncEffects decoder(FriendlyByteBuf buffer) {
+        int entityID = buffer.readInt();
+        Collection<MobEffectInstance> effects = buffer.readCollection(ArrayList::new, friendlyByteBuf -> {
+            return MobEffectInstance.load(friendlyByteBuf.readNbt());
+        });
+        return new MessageSyncEffects(entityID, effects);
+    }
+
+    public void encoder(FriendlyByteBuf buffer) {
+        buffer.writeInt(entityID);
+        buffer.writeCollection(effects, (friendlyByteBuf, mobEffectInstance) -> {
+            friendlyByteBuf.writeNbt(mobEffectInstance.save(new CompoundTag()));
+        });
+
+    }
+
+    public boolean handler(Supplier<NetworkEvent.Context> contextSupplier) {
+        contextSupplier.get().enqueueWork(() -> {
+            contextSupplier.get().setPacketHandled(true);
+
+            if (contextSupplier.get().getDirection() == NetworkDirection.PLAY_TO_CLIENT) {
+                Entity entity = Minecraft.getInstance().level.getEntity(entityID);
+                if (entity instanceof LivingEntity dragon) {
+                    Iterator<MobEffectInstance> iterator = dragon.getActiveEffects().iterator();
+
+                    boolean flag;
+                    for(flag = false; iterator.hasNext(); flag = true) {
+                        MobEffectInstance effect = iterator.next();
+                        iterator.remove();
+                    }
+                    for (MobEffectInstance effect :
+                            effects) {
+                        dragon.forceAddEffect(effect, null);
+                    }
+                }
+            } else if (contextSupplier.get().getDirection() == NetworkDirection.PLAY_TO_SERVER) {
+                ServerPlayer serverPlayer = contextSupplier.get().getSender();
+                if (serverPlayer != null) {
+                    Entity entity = serverPlayer.level.getEntity(entityID);
+                    if (entity instanceof LivingEntity dragon) {
+                        IceAndFire.sendMSGToPlayer(new MessageSyncEffects(dragon), serverPlayer);
+                    }
+                }
+            }
+        });
+        return true;
+    }
+
+}

--- a/src/main/java/com/github/alexthe666/iceandfire/mixin/entity/AreaEffectCloudMixin.java
+++ b/src/main/java/com/github/alexthe666/iceandfire/mixin/entity/AreaEffectCloudMixin.java
@@ -1,0 +1,265 @@
+package com.github.alexthe666.iceandfire.mixin.entity;
+
+import com.github.alexthe666.iceandfire.entity.EntityMutlipartPart;
+import com.google.common.collect.Lists;
+import net.minecraft.core.particles.ParticleOptions;
+import net.minecraft.core.particles.ParticleTypes;
+import net.minecraft.util.Mth;
+import net.minecraft.world.effect.MobEffectInstance;
+import net.minecraft.world.entity.AreaEffectCloud;
+import net.minecraft.world.entity.Entity;
+import net.minecraft.world.entity.EntityType;
+import net.minecraft.world.entity.LivingEntity;
+import net.minecraft.world.item.alchemy.Potion;
+import net.minecraft.world.level.Level;
+import net.minecraft.world.phys.Vec3;
+import org.spongepowered.asm.mixin.Final;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+import javax.annotation.Nullable;
+import java.util.List;
+import java.util.Map;
+
+@Mixin(AreaEffectCloud.class)
+public abstract class AreaEffectCloudMixin extends Entity {
+    public AreaEffectCloudMixin(EntityType<?> pEntityType, Level pLevel) {
+        super(pEntityType, pLevel);
+    }
+
+    @Shadow public abstract boolean isWaiting();
+
+    @Shadow public abstract float getRadius();
+
+    @Shadow private int waitTime;
+
+    @Shadow private int duration;
+
+    @Shadow public abstract int getColor();
+
+    @Shadow public abstract ParticleOptions getParticle();
+
+    @Shadow protected abstract void setWaiting(boolean pWaiting);
+
+    @Shadow private float radiusPerTick;
+
+    @Shadow public abstract void setRadius(float pRadius);
+
+    @Shadow @Final private Map<Entity, Integer> victims;
+
+    @Shadow private Potion potion;
+
+    @Shadow @Final private List<MobEffectInstance> effects;
+
+    @Shadow private float radiusOnUse;
+
+    @Shadow private int durationOnUse;
+
+    @Shadow private int reapplicationDelay;
+
+    @Shadow @Nullable public abstract LivingEntity getOwner();
+
+    @Inject(
+            method = "tick",
+            at = @At(value = "HEAD"),
+            cancellable = true
+    )
+    private void $tick(CallbackInfo ci) {
+        roadblock$tick();
+        ci.cancel();
+    }
+
+    public void roadblock$tick() {
+        super.tick();
+        boolean flag = this.isWaiting();
+        float f = this.getRadius();
+        if (this.level.isClientSide) {
+            if (flag && this.random.nextBoolean()) {
+                return;
+            }
+
+            ParticleOptions particleoptions = this.getParticle();
+            int i;
+            float f1;
+            if (flag) {
+                i = 2;
+                f1 = 0.2F;
+            } else {
+                i = Mth.ceil((float)Math.PI * f * f);
+                f1 = f;
+            }
+
+            for(int j = 0; j < i; ++j) {
+                float f2 = this.random.nextFloat() * ((float)Math.PI * 2F);
+                float f3 = Mth.sqrt(this.random.nextFloat()) * f1;
+                double d0 = this.getX() + (double)(Mth.cos(f2) * f3);
+                double d2 = this.getY();
+                double d4 = this.getZ() + (double)(Mth.sin(f2) * f3);
+                double d5;
+                double d6;
+                double d7;
+                if (particleoptions.getType() != ParticleTypes.ENTITY_EFFECT) {
+                    if (flag) {
+                        d5 = 0.0D;
+                        d6 = 0.0D;
+                        d7 = 0.0D;
+                    } else {
+                        d5 = (0.5D - this.random.nextDouble()) * 0.15D;
+                        d6 = (double)0.01F;
+                        d7 = (0.5D - this.random.nextDouble()) * 0.15D;
+                    }
+                } else {
+                    int k = flag && this.random.nextBoolean() ? 16777215 : this.getColor();
+                    d5 = (double)((float)(k >> 16 & 255) / 255.0F);
+                    d6 = (double)((float)(k >> 8 & 255) / 255.0F);
+                    d7 = (double)((float)(k & 255) / 255.0F);
+                }
+
+                this.level.addAlwaysVisibleParticle(particleoptions, d0, d2, d4, d5, d6, d7);
+            }
+        } else {
+            if (this.tickCount >= this.waitTime + this.duration) {
+                this.discard();
+                return;
+            }
+
+            boolean flag1 = this.tickCount < this.waitTime;
+            if (flag != flag1) {
+                this.setWaiting(flag1);
+            }
+
+            if (flag1) {
+                return;
+            }
+
+            if (this.radiusPerTick != 0.0F) {
+                f += this.radiusPerTick;
+                if (f < 0.5F) {
+                    this.discard();
+                    return;
+                }
+
+                this.setRadius(f);
+            }
+
+            if (this.tickCount % 5 == 0) {
+                this.victims.entrySet().removeIf((p_146784_) -> {
+                    return this.tickCount >= p_146784_.getValue();
+                });
+                List<MobEffectInstance> list = Lists.newArrayList();
+
+                for(MobEffectInstance mobeffectinstance : this.potion.getEffects()) {
+                    list.add(new MobEffectInstance(mobeffectinstance.getEffect(), mobeffectinstance.getDuration() / 4, mobeffectinstance.getAmplifier(), mobeffectinstance.isAmbient(), mobeffectinstance.isVisible()));
+                }
+
+                list.addAll(this.effects);
+                if (list.isEmpty()) {
+                    this.victims.clear();
+                } else {
+                    AreaEffectCloud thisInstance = (AreaEffectCloud)(Object) this;
+//                    List<LivingEntity> list1 = this.level.getEntitiesOfClass(LivingEntity.class, this.getBoundingBox());
+                    List<Entity> list1 = thisInstance.level.getEntitiesOfClass(Entity.class, thisInstance.getBoundingBox(), entity -> (
+                            (entity instanceof EntityMutlipartPart dragonPart && dragonPart.getParent() != null)
+                                    || entity instanceof LivingEntity
+                    ));
+                    if (!list1.isEmpty()) {
+                        for(Entity entity : list1) {
+                            if (entity instanceof EntityMutlipartPart dragonPart) {
+                                LivingEntity parent = dragonPart.getRootParent();
+
+                                if (!this.victims.containsKey(parent) && parent.isAffectedByPotions()) {
+                                    double d8 = dragonPart.getX() - this.getX();
+                                    double d1 = dragonPart.getZ() - this.getZ();
+                                    // ***Modified***
+                                    // Vanilla criteria:
+//                                double d3 = d8 * d8 + d1 * d1;
+//                                if (d3 <= (double)(f * f)) {
+                                    Vec3 potionPos = this.getPosition(1.0f);
+                                    double d3 = dragonPart.getBoundingBox().clip(potionPos, dragonPart.getPosition(1.0f)).orElse(potionPos).subtract(potionPos).length();
+                                    if (d3 <= f) {
+                                        // ***Modify End***
+                                        this.victims.put(parent, this.tickCount + this.reapplicationDelay);
+
+                                        for (MobEffectInstance mobeffectinstance1 : list) {
+                                            if (mobeffectinstance1.getEffect().isInstantenous()) {
+                                                mobeffectinstance1.getEffect().applyInstantenousEffect(this, this.getOwner(), parent, mobeffectinstance1.getAmplifier(), 0.5D);
+                                            } else {
+                                                parent.addEffect(new MobEffectInstance(mobeffectinstance1), this);
+                                            }
+                                        }
+
+                                        if (this.radiusOnUse != 0.0F) {
+                                            f += this.radiusOnUse;
+                                            if (f < 0.5F) {
+                                                this.discard();
+                                                return;
+                                            }
+
+                                            this.setRadius(f);
+                                        }
+
+                                        if (this.durationOnUse != 0) {
+                                            this.duration += this.durationOnUse;
+                                            if (this.duration <= 0) {
+                                                this.discard();
+                                                return;
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                            if (entity instanceof LivingEntity livingentity) {
+                                if (!this.victims.containsKey(livingentity) && livingentity.isAffectedByPotions()) {
+                                    double d8 = livingentity.getX() - this.getX();
+                                    double d1 = livingentity.getZ() - this.getZ();
+                                    // ***Modified***
+                                    // Vanilla criteria:
+//                                double d3 = d8 * d8 + d1 * d1;
+//                                if (d3 <= (double)(f * f)) {
+                                    Vec3 potionPos = this.getPosition(1.0f);
+                                    double d3 = livingentity.getBoundingBox().clip(potionPos, livingentity.getPosition(1.0f)).orElse(potionPos).subtract(potionPos).length();
+                                    if (d3 <= f) {
+                                        // ***Modify End***
+                                        this.victims.put(livingentity, this.tickCount + this.reapplicationDelay);
+
+                                        for (MobEffectInstance mobeffectinstance1 : list) {
+                                            if (mobeffectinstance1.getEffect().isInstantenous()) {
+                                                mobeffectinstance1.getEffect().applyInstantenousEffect(this, this.getOwner(), livingentity, mobeffectinstance1.getAmplifier(), 0.5D);
+                                            } else {
+                                                livingentity.addEffect(new MobEffectInstance(mobeffectinstance1), this);
+                                            }
+                                        }
+
+                                        if (this.radiusOnUse != 0.0F) {
+                                            f += this.radiusOnUse;
+                                            if (f < 0.5F) {
+                                                this.discard();
+                                                return;
+                                            }
+
+                                            this.setRadius(f);
+                                        }
+
+                                        if (this.durationOnUse != 0) {
+                                            this.duration += this.durationOnUse;
+                                            if (this.duration <= 0) {
+                                                this.discard();
+                                                return;
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+    }
+
+
+}

--- a/src/main/java/com/github/alexthe666/iceandfire/mixin/entity/ThrownPotionMixin.java
+++ b/src/main/java/com/github/alexthe666/iceandfire/mixin/entity/ThrownPotionMixin.java
@@ -1,0 +1,106 @@
+package com.github.alexthe666.iceandfire.mixin.entity;
+
+import com.github.alexthe666.iceandfire.entity.EntityMutlipartPart;
+import net.minecraft.world.effect.MobEffect;
+import net.minecraft.world.effect.MobEffectInstance;
+import net.minecraft.world.entity.Entity;
+import net.minecraft.world.entity.EntityType;
+import net.minecraft.world.entity.LivingEntity;
+import net.minecraft.world.entity.projectile.ThrowableItemProjectile;
+import net.minecraft.world.entity.projectile.ThrownPotion;
+import net.minecraft.world.level.Level;
+import net.minecraft.world.phys.AABB;
+import net.minecraft.world.phys.Vec3;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+import javax.annotation.Nullable;
+import java.util.List;
+
+@Mixin(ThrownPotion.class)
+public abstract class ThrownPotionMixin extends ThrowableItemProjectile {
+    public ThrownPotionMixin(EntityType<? extends ThrowableItemProjectile> pEntityType, Level pLevel) {
+        super(pEntityType, pLevel);
+    }
+
+    @Inject(
+            method = "applySplash",
+            at = @At(value = "HEAD"),
+            cancellable = true
+    )
+    private void $applySplash(List<MobEffectInstance> pEffectInstances, Entity pTarget, CallbackInfo ci) {
+        roadblock$applySplash(pEffectInstances, pTarget);
+        ci.cancel();
+    }
+
+    private void roadblock$applySplash(List<MobEffectInstance> pEffectInstances, @Nullable Entity pTarget) {
+        ThrownPotion potion = (ThrownPotion)(Object) this;
+
+        AABB aabb = potion.getBoundingBox().inflate(4.0d, 2.0d, 4.0d);
+        Vec3 potionPos = potion.getPosition(1.0f);
+        List<Entity> entityList = potion.level.getEntitiesOfClass(Entity.class, aabb, entity -> (
+                (entity instanceof EntityMutlipartPart dragonPart && dragonPart.getParent() != null)
+                        || entity instanceof LivingEntity
+        ));
+        if (!entityList.isEmpty()) {
+            Entity thrower = potion.getEffectSource();
+
+            for (Entity effectedEntity : entityList) {
+                if (effectedEntity instanceof EntityMutlipartPart dragonPart) {
+                    LivingEntity parent = dragonPart.getRootParent();
+                    if (parent == null) {
+                        break;
+                    }
+
+                    if (parent.isAffectedByPotions()) {
+                        double d0 = dragonPart.getBoundingBox().clip(potionPos, dragonPart.getPosition(1.0f)).orElse(potionPos).subtract(potionPos).length();
+                        if (d0 < 16.0D) {
+                            double d1 = 1.0D - Math.sqrt(d0) / 4.0D;
+                            if (dragonPart == pTarget) {
+                                d1 = 1.0D;
+                            }
+
+                            for (MobEffectInstance mobeffectinstance : pEffectInstances) {
+                                MobEffect mobeffect = mobeffectinstance.getEffect();
+                                if (mobeffect.isInstantenous()) {
+                                    mobeffect.applyInstantenousEffect(potion, potion.getOwner(), parent, mobeffectinstance.getAmplifier(), d1);
+                                } else {
+                                    int i = (int)(d1 * (double)mobeffectinstance.getDuration() + 0.5D);
+                                    if (i > 20) {
+                                        parent.addEffect(new MobEffectInstance(mobeffect, i, mobeffectinstance.getAmplifier(), mobeffectinstance.isAmbient(), mobeffectinstance.isVisible()), thrower);
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+                if (effectedEntity instanceof LivingEntity livingEntity) {
+                    if (livingEntity.isAffectedByPotions()) {
+                        double d0 = livingEntity.getBoundingBox().clip(potionPos, livingEntity.getPosition(1.0f)).orElse(potionPos).subtract(potionPos).length();
+                        if (d0 < 16.0D) {
+                            double d1 = 1.0D - Math.sqrt(d0) / 4.0D;
+                            if (livingEntity == pTarget) {
+                                d1 = 1.0D;
+                            }
+
+                            for(MobEffectInstance mobeffectinstance : pEffectInstances) {
+                                MobEffect mobeffect = mobeffectinstance.getEffect();
+                                if (mobeffect.isInstantenous()) {
+                                    mobeffect.applyInstantenousEffect(potion, potion.getOwner(), livingEntity, mobeffectinstance.getAmplifier(), d1);
+                                } else {
+                                    int i = (int)(d1 * (double)mobeffectinstance.getDuration() + 0.5D);
+                                    if (i > 20) {
+                                        livingEntity.addEffect(new MobEffectInstance(mobeffect, i, mobeffectinstance.getAmplifier(), mobeffectinstance.isAmbient(), mobeffectinstance.isVisible()), thrower);
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+    }
+}

--- a/src/main/java/com/github/alexthe666/iceandfire/mixin/world/gen/MuteSetBlockFarChunk.java
+++ b/src/main/java/com/github/alexthe666/iceandfire/mixin/world/gen/MuteSetBlockFarChunk.java
@@ -1,4 +1,4 @@
-package com.github.alexthe666.iceandfire.world.gen.mixin;
+package com.github.alexthe666.iceandfire.mixin.world.gen;
 
 import net.minecraft.server.level.WorldGenRegion;
 import org.spongepowered.asm.mixin.Mixin;

--- a/src/main/java/com/github/alexthe666/iceandfire/mixin/world/gen/NoLakesInStructuresMixin.java
+++ b/src/main/java/com/github/alexthe666/iceandfire/mixin/world/gen/NoLakesInStructuresMixin.java
@@ -1,4 +1,4 @@
-package com.github.alexthe666.iceandfire.world.gen.mixin;
+package com.github.alexthe666.iceandfire.mixin.world.gen;
 
 import com.github.alexthe666.iceandfire.world.IafWorldRegistry;
 import net.minecraft.server.level.WorldGenRegion;

--- a/src/main/resources/META-INF/accesstransformer.cfg
+++ b/src/main/resources/META-INF/accesstransformer.cfg
@@ -19,3 +19,8 @@ public-f net.minecraft.client.renderer.Sheets f_173376_ #BANNER_MATERIALS
 public-f net.minecraft.client.renderer.Sheets f_173377_ #SHIELD_MATERIALS
 public-f net.minecraft.client.renderer.Sheets m_173387_(Lnet/minecraft/world/level/block/entity/BannerPattern;)Lnet/minecraft/client/resources/model/Material; #createBannerMaterial
 public-f net.minecraft.client.renderer.Sheets m_173389_(Lnet/minecraft/world/level/block/entity/BannerPattern;)Lnet/minecraft/client/resources/model/Material;
+protected net.minecraft.client.gui.screens.inventory.EffectRenderingInventoryScreen m_194014_(Lcom/mojang/blaze3d/vertex/PoseStack;II)V # renderEffects
+protected net.minecraft.client.gui.screens.inventory.EffectRenderingInventoryScreen m_194002_(Lcom/mojang/blaze3d/vertex/PoseStack;IILjava/lang/Iterable;Z)V # renderBackgrounds
+protected net.minecraft.client.gui.screens.inventory.EffectRenderingInventoryScreen m_194008_(Lcom/mojang/blaze3d/vertex/PoseStack;IILjava/lang/Iterable;Z)V # renderIcons
+protected net.minecraft.client.gui.screens.inventory.EffectRenderingInventoryScreen m_98722_(Lcom/mojang/blaze3d/vertex/PoseStack;IILjava/lang/Iterable;)V # renderLabels
+protected net.minecraft.client.gui.screens.inventory.EffectRenderingInventoryScreen m_194000_(Lnet/minecraft/world/effect/MobEffectInstance;)Lnet/minecraft/network/chat/Component; # getEffectName

--- a/src/main/resources/iceandfire.mixins.json
+++ b/src/main/resources/iceandfire.mixins.json
@@ -1,11 +1,13 @@
 {
   "required": true,
-  "package": "com.github.alexthe666.iceandfire.world.gen.mixin",
+  "package": "com.github.alexthe666.iceandfire.mixin",
   "compatibilityLevel": "JAVA_17",
   "refmap": "iceandfire.refmap.json",
   "mixins": [
-    "NoLakesInStructuresMixin",
-    "MuteSetBlockFarChunk"
+    "entity.AreaEffectCloudMixin",
+    "entity.ThrownPotionMixin",
+    "world.gen.MuteSetBlockFarChunk",
+    "world.gen.NoLakesInStructuresMixin"
   ],
   "client": [
   ],


### PR DESCRIPTION
Vanilla thrown potions works poorly with dragons for 2 reasons, a) mutiparts don't deliver their effects to their parent and b) the central coordinates are used to determine the distance between potion and living entities, due to dragons' large size this means you have to throw the potion right under their feet to let them gain potion effects.

This fix the issue by letting mutiparts deliver the potion effects to their owners (all sort of mutiparts, such as sea serpents') and calculate the distance to the potion using the boarder of the bounding box. 

This overwrites the vanilla potion and lingering potion method, so it might have a compatibility issue.