### PR TITLE
allow totems to resurrect dragons and statues

### DIFF
--- a/src/main/java/com/github/alexthe666/iceandfire/entity/EntityDragonBase.java
+++ b/src/main/java/com/github/alexthe666/iceandfire/entity/EntityDragonBase.java
@@ -90,7 +90,7 @@ import java.util.List;
 import java.util.Random;
 import java.util.UUID;
 
-public abstract class EntityDragonBase extends TamableAnimal implements IPassabilityNavigator, ISyncMount, IFlyingMount, IMultipartEntity, IAnimatedEntity, IDragonFlute, IDeadMob, IVillagerFear, IAnimalFear, IDropArmor, IHasCustomizableAttributes, ICustomSizeNavigator, ICustomMoveController, ContainerListener, IResurrectable {
+public abstract class EntityDragonBase extends TamableAnimal implements IPassabilityNavigator, ISyncMount, IFlyingMount, IMultipartEntity, IAnimatedEntity, IDragonFlute, IDeadMob, IVillagerFear, IAnimalFear, IDropArmor, IHasCustomizableAttributes, ICustomSizeNavigator, ICustomMoveController, ContainerListener, IResurrectable, IBlacklistedFromStatues {
 
     public static final int FLIGHT_CHANCE_PER_TICK = 1500;
     protected static final EntityDataAccessor<Boolean> SWIMMING = SynchedEntityData.defineId(EntityDragonBase.class, EntityDataSerializers.BOOLEAN);
@@ -2009,6 +2009,11 @@ public abstract class EntityDragonBase extends TamableAnimal implements IPassabi
     @Override
     public boolean isImmobile() {
         return this.getHealth() <= 0.0F || isOrderedToSit() && !this.isVehicle() || this.isModelDead() || this.isPassenger();
+    }
+
+    @Override
+    public boolean canBeTurnedToStone() {
+        return this.getAgeInDays() < 95;
     }
 
     @Override

--- a/src/main/java/com/github/alexthe666/iceandfire/entity/EntityDragonBase.java
+++ b/src/main/java/com/github/alexthe666/iceandfire/entity/EntityDragonBase.java
@@ -90,7 +90,7 @@ import java.util.List;
 import java.util.Random;
 import java.util.UUID;
 
-public abstract class EntityDragonBase extends TamableAnimal implements IPassabilityNavigator, ISyncMount, IFlyingMount, IMultipartEntity, IAnimatedEntity, IDragonFlute, IDeadMob, IVillagerFear, IAnimalFear, IDropArmor, IHasCustomizableAttributes, ICustomSizeNavigator, ICustomMoveController, ContainerListener {
+public abstract class EntityDragonBase extends TamableAnimal implements IPassabilityNavigator, ISyncMount, IFlyingMount, IMultipartEntity, IAnimatedEntity, IDragonFlute, IDeadMob, IVillagerFear, IAnimalFear, IDropArmor, IHasCustomizableAttributes, ICustomSizeNavigator, ICustomMoveController, ContainerListener, IResurrectable {
 
     public static final int FLIGHT_CHANCE_PER_TICK = 1500;
     protected static final EntityDataAccessor<Boolean> SWIMMING = SynchedEntityData.defineId(EntityDragonBase.class, EntityDataSerializers.BOOLEAN);
@@ -2009,6 +2009,43 @@ public abstract class EntityDragonBase extends TamableAnimal implements IPassabi
     @Override
     public boolean isImmobile() {
         return this.getHealth() <= 0.0F || isOrderedToSit() && !this.isVehicle() || this.isModelDead() || this.isPassenger();
+    }
+
+    @Override
+    public boolean canResurrectBy(ItemStack itemStack) {
+        return this.isMobDead()
+                && !this.isSkeletal()
+                && this.getDeathStage() == 0
+                && itemStack.getItem() == Items.TOTEM_OF_UNDYING
+                && !itemStack.isEmpty();
+    }
+
+    @Override
+    public boolean resurrect() {
+        int deathStage = this.getDeathStage();
+
+        if (deathStage == 0) {
+            this.setHealth((float) Math.ceil(this.getMaxHealth() / 20.0f));
+            this.removeAllEffects();
+            this.addEffect(new MobEffectInstance(MobEffects.REGENERATION, 900, 1));
+            this.addEffect(new MobEffectInstance(MobEffects.ABSORPTION, 100, 1));
+            this.addEffect(new MobEffectInstance(MobEffects.FIRE_RESISTANCE, 800, 0));
+            this.level.broadcastEntityEvent(this, (byte) 35);
+
+            this.setDeathStage(0);
+            this.setModelDead(false);
+            this.setNoAi(false);
+
+            return true;
+        }
+        // this will allow skinned dragon resurrection
+//        else if (deathStage > 0 && deathStage <= 2) {
+////            util.spawnParticleForce(dragon.world, ParticleTypes.HAPPY_VILLAGER, )
+//            this.level.broadcastEntityEvent(this, (byte) 35);
+//            this.setDeathStage(deathStage - 1);
+//            return true;
+//        }
+        return false;
     }
 
     @Override

--- a/src/main/java/com/github/alexthe666/iceandfire/entity/util/IResurrectable.java
+++ b/src/main/java/com/github/alexthe666/iceandfire/entity/util/IResurrectable.java
@@ -1,0 +1,31 @@
+package com.github.alexthe666.iceandfire.entity.util;
+
+import net.minecraft.world.item.ItemStack;
+
+public interface IResurrectable {
+
+    /**
+     * Determine if the target should be resurrected by the given itemStack
+     *
+     * @param itemStack The given itemStack used to perform the resurrection ritual
+     * @return True if they should, false if not
+     */
+    default boolean canResurrectBy(ItemStack itemStack) {
+        return false;
+    }
+
+
+    /**
+     * Perform resurrection
+     * @return True if the resurrection is success, false if not
+     */
+    boolean resurrect();
+
+    /**
+     * The itemStack should shrink by this value
+     * @return item counts to consume
+     */
+    default int getResurrectCost() {
+        return 1;
+    }
+}


### PR DESCRIPTION
This is not a bug fix, this is a new feature. I found the vanilla totem of undying is not very useful so I implement this idea for my mod. And since the code is written I thought I put it here, hopefully it is useful in some way.

This will allow players right click a dead dragon's body (not skeletal one), or a stoned creature's statue, to bring them back alive, just like how player is saved by the totem within their hand.