### PR TITLE
avoid stone statue being targeted by warden (1.19.2)

### DIFF
--- a/src/generated/resources/data/iceandfire/tags/entity_types/immune_to_gorgon_stone.json
+++ b/src/generated/resources/data/iceandfire/tags/entity_types/immune_to_gorgon_stone.json
@@ -1,5 +1,6 @@
 {
   "values": [
-    "#forge:bosses"
+    "#forge:bosses",
+    "minecraft:warden"
   ]
 }

--- a/src/main/java/com/github/alexthe666/iceandfire/datagen/tags/IafEntityTags.java
+++ b/src/main/java/com/github/alexthe666/iceandfire/datagen/tags/IafEntityTags.java
@@ -21,7 +21,8 @@ public class IafEntityTags extends EntityTypeTagsProvider {
     @Override
     protected void addTags() {
         tag(IMMUNE_TO_GORGON_STONE)
-                .addTag(Tags.EntityTypes.BOSSES);
+                .addTag(Tags.EntityTypes.BOSSES)
+                .add(EntityType.WARDEN);
     }
 
     private static TagKey<EntityType<?>> createKey(final String name) {

--- a/src/main/java/com/github/alexthe666/iceandfire/entity/EntityStoneStatue.java
+++ b/src/main/java/com/github/alexthe666/iceandfire/entity/EntityStoneStatue.java
@@ -156,8 +156,8 @@ public class EntityStoneStatue extends LivingEntity implements IBlacklistedFromS
     }
 
     @Override
-    public boolean hurt(@NotNull DamageSource source, float amount) {
-        return source == DamageSource.OUT_OF_WORLD;
+    public boolean isInvulnerable() {
+        return true;
     }
 
     @Override


### PR DESCRIPTION
- see Warden#canTargetEntity
- OUT_OF_WORLD still does damage
- fix #5103