### PR TITLE
bump dragonsteel tier (1.19.2)

### DIFF
--- a/src/main/java/com/github/alexthe666/iceandfire/item/DragonSteelTier.java
+++ b/src/main/java/com/github/alexthe666/iceandfire/item/DragonSteelTier.java
@@ -27,7 +27,7 @@ public class DragonSteelTier {
         return TierSortingRegistry.registerTier(
             new ForgeTier(5, 8000, 10, 21, 10, DRAGONSTEEL_TIER_TAG, ingredient),
             new ResourceLocation(IceAndFire.MODID, name),
-            List.of(Tiers.DIAMOND), List.of());
+            List.of(Tiers.NETHERITE), List.of());
     }
 
 

--- a/src/main/java/com/github/alexthe666/iceandfire/item/DragonSteelTier.java
+++ b/src/main/java/com/github/alexthe666/iceandfire/item/DragonSteelTier.java
@@ -25,7 +25,7 @@ public class DragonSteelTier {
 
     private static Tier createTierWithRepairItem(Supplier<Ingredient> ingredient, String name) {
         return TierSortingRegistry.registerTier(
-            new ForgeTier(5, 8000, 10, 21, 10, DRAGONSTEEL_TIER_TAG, ingredient),
+            new ForgeTier(4, 8000, 10, 21, 10, DRAGONSTEEL_TIER_TAG, ingredient),
             new ResourceLocation(IceAndFire.MODID, name),
             List.of(Tiers.NETHERITE), List.of());
     }

--- a/src/main/java/com/github/alexthe666/iceandfire/item/IafItemRegistry.java
+++ b/src/main/java/com/github/alexthe666/iceandfire/item/IafItemRegistry.java
@@ -46,10 +46,10 @@ public class IafItemRegistry {
     public static CustomArmorMaterial DRAGONSTEEL_LIGHTNING_ARMOR_MATERIAL = new DragonsteelArmorMaterial("dragonsteel_lightning", (int) (0.02D * IafConfig.dragonsteelBaseDurabilityEquipment), new int[]{IafConfig.dragonsteelBaseArmor - 6, IafConfig.dragonsteelBaseArmor - 3, IafConfig.dragonsteelBaseArmor, IafConfig.dragonsteelBaseArmor - 5}, 30, SoundEvents.ARMOR_EQUIP_DIAMOND, IafConfig.dragonsteelBaseArmorToughness);
     public static CustomToolMaterial SILVER_TOOL_MATERIAL = new CustomToolMaterial("silver", 2, 460, 1.0F, 11.0F, 18);
     public static CustomToolMaterial COPPER_TOOL_MATERIAL = new CustomToolMaterial("copper", 2, 300, 0.0F, 0.7F, 10);
-    public static CustomToolMaterial DRAGONBONE_TOOL_MATERIAL = new CustomToolMaterial("Dragonbone", 4, 1660, 4.0F, 10.0F, 22);
-    public static CustomToolMaterial FIRE_DRAGONBONE_TOOL_MATERIAL = new CustomToolMaterial("FireDragonbone", 4, 2000, 5.5F, 10F, 22);
-    public static CustomToolMaterial ICE_DRAGONBONE_TOOL_MATERIAL = new CustomToolMaterial("IceDragonbone", 4, 2000, 5.5F, 10F, 22);
-    public static CustomToolMaterial LIGHTNING_DRAGONBONE_TOOL_MATERIAL = new CustomToolMaterial("LightningDragonbone", 4, 2000, 5.5F, 10F, 22);
+    public static CustomToolMaterial DRAGONBONE_TOOL_MATERIAL = new CustomToolMaterial("Dragonbone", 3, 1660, 4.0F, 10.0F, 22);
+    public static CustomToolMaterial FIRE_DRAGONBONE_TOOL_MATERIAL = new CustomToolMaterial("FireDragonbone", 3, 2000, 5.5F, 10F, 22);
+    public static CustomToolMaterial ICE_DRAGONBONE_TOOL_MATERIAL = new CustomToolMaterial("IceDragonbone", 3, 2000, 5.5F, 10F, 22);
+    public static CustomToolMaterial LIGHTNING_DRAGONBONE_TOOL_MATERIAL = new CustomToolMaterial("LightningDragonbone", 3, 2000, 5.5F, 10F, 22);
     public static CustomToolMaterial TROLL_WEAPON_TOOL_MATERIAL = new CustomToolMaterial("trollWeapon", 2, 300, 1F, 10F, 1);
     public static CustomToolMaterial MYRMEX_CHITIN_TOOL_MATERIAL = new CustomToolMaterial("MyrmexChitin", 3, 600, 1.0F, 6.0F, 8);
     public static CustomToolMaterial HIPPOGRYPH_SWORD_TOOL_MATERIAL = new CustomToolMaterial("HippogryphSword", 2, 500, 2.5F, 10F, 10);


### PR DESCRIPTION
some blocks are marked as needing netherite tools 
dragonsteel should be considered above or equal to it but in its current state it wouldn't considered effective against such blocks