### PR TITLE
Adjust pickup AI logic

### DIFF
--- a/src/generated/resources/data/iceandfire/tags/items/tnt.json
+++ b/src/generated/resources/data/iceandfire/tags/items/tnt.json
@@ -1,0 +1,5 @@
+{
+  "values": [
+    "minecraft:tnt"
+  ]
+}

--- a/src/main/java/com/github/alexthe666/iceandfire/api/FoodUtils.java
+++ b/src/main/java/com/github/alexthe666/iceandfire/api/FoodUtils.java
@@ -3,33 +3,51 @@ package com.github.alexthe666.iceandfire.api;
 import net.minecraft.tags.ItemTags;
 import net.minecraft.world.entity.AgeableMob;
 import net.minecraft.world.entity.Entity;
+import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.food.FoodProperties;
 import net.minecraft.world.item.ItemStack;
 
-public class FoodUtils {
+import javax.annotation.Nullable;
 
-    public static int getFoodPoints(Entity entity) {
+public class FoodUtils {
+    public static int getFoodPoints(final Entity entity) {
         int foodPoints = Math.round(entity.getBbWidth() * entity.getBbHeight() * 10);
+
         if (entity instanceof AgeableMob) {
             return foodPoints;
         }
+
         if (entity instanceof Player) {
             return 15;
         }
+
         return 0;
     }
 
-    public static int getFoodPoints(ItemStack item, boolean meatOnly, boolean includeFish) {
-        if (item != null && item != ItemStack.EMPTY && item.getItem() != null && item.getItem().getFoodProperties() != null) {
-            int food = item.getItem().getFoodProperties().getNutrition() * 10;
+    public static int getFoodPoints(final ItemStack stack, boolean meatOnly, boolean includeFish) {
+        return getFoodPoints(null, stack, meatOnly, includeFish);
+    }
+
+    public static int getFoodPoints(final @Nullable LivingEntity livingEntity, final ItemStack stack, boolean meatOnly, boolean includeFish) {
+        if (stack == null) {
+            return 0;
+        }
+
+        FoodProperties foodProperties = stack.getFoodProperties(livingEntity);
+
+        if (foodProperties != null) {
+            int nutrition = foodProperties.getNutrition() * 10;
+
             if (!meatOnly) {
-                return food;
-            } else if (item.getItem().getFoodProperties().isMeat()) {
-                return food;
-            } else if (includeFish && item.is(ItemTags.FISHES)) {
-                return food;
+                return nutrition;
+            } else if (foodProperties.isMeat()) {
+                return nutrition;
+            } else if (includeFish && stack.is(ItemTags.FISHES)) {
+                return nutrition;
             }
         }
+
         return 0;
     }
 }

--- a/src/main/java/com/github/alexthe666/iceandfire/datagen/tags/IafItemTags.java
+++ b/src/main/java/com/github/alexthe666/iceandfire/datagen/tags/IafItemTags.java
@@ -55,6 +55,7 @@ public class IafItemTags extends ItemTagsProvider {
     public static TagKey<Item> DRAGON_BLOODS = createKey("dragon_bloods");
     public static TagKey<Item> DRAGON_HEARTS = createKey("dragon_hearts");
 
+    public static TagKey<Item> TNT = createKey("tnt");
     public static TagKey<Item> BREED_AMPITHERE = createKey("breed_ampithere");
     public static TagKey<Item> BREED_HIPPOCAMPUS = createKey("breed_hippocampus");
     public static TagKey<Item> BREED_HIPPOGRYPH = createKey("breed_hippogryph");
@@ -182,6 +183,9 @@ public class IafItemTags extends ItemTagsProvider {
                 .add(Items.CHICKEN, Items.COOKED_CHICKEN)
                 .add(Items.MUTTON, Items.COOKED_MUTTON)
                 .add(Items.PORKCHOP, Items.COOKED_PORKCHOP);
+
+        tag(TNT)
+                .add(Items.TNT);
 
         tag(BREED_AMPITHERE)
                 .add(Items.COOKIE);

--- a/src/main/java/com/github/alexthe666/iceandfire/entity/EntityAmphithere.java
+++ b/src/main/java/com/github/alexthe666/iceandfire/entity/EntityAmphithere.java
@@ -249,7 +249,7 @@ public class EntityAmphithere extends TamableAnimal implements ISyncMount, IAnim
         this.targetSelector.addGoal(1, new OwnerHurtTargetGoal(this));
         this.targetSelector.addGoal(2, new OwnerHurtByTargetGoal(this));
         this.targetSelector.addGoal(3, new AmphithereAIHurtByTarget(this, false, new Class[0]));
-        this.targetSelector.addGoal(3, new AmphithereAITargetItems<>(this, false));
+        this.targetSelector.addGoal(3, new AmphithereAITargetItems(this));
     }
 
     public boolean isStill() {

--- a/src/main/java/com/github/alexthe666/iceandfire/entity/EntityCockatrice.java
+++ b/src/main/java/com/github/alexthe666/iceandfire/entity/EntityCockatrice.java
@@ -135,7 +135,7 @@ public class EntityCockatrice extends TamableAnimal implements IAnimatedEntity, 
         this.goalSelector.addGoal(5, new CockatriceAIAggroLook(this));
         this.goalSelector.addGoal(6, new LookAtPlayerGoal(this, LivingEntity.class, 6.0F));
         this.goalSelector.addGoal(7, new RandomLookAroundGoal(this));
-        this.targetSelector.addGoal(1, new CockatriceAITargetItems(this, false));
+        this.targetSelector.addGoal(1, new CockatriceAITargetItems(this, false, false));
         this.targetSelector.addGoal(2, new OwnerHurtByTargetGoal(this));
         this.targetSelector.addGoal(3, new OwnerHurtTargetGoal(this));
         this.targetSelector.addGoal(4, new HurtByTargetGoal(this));

--- a/src/main/java/com/github/alexthe666/iceandfire/entity/EntityDeathWorm.java
+++ b/src/main/java/com/github/alexthe666/iceandfire/entity/EntityDeathWorm.java
@@ -88,7 +88,7 @@ public class EntityDeathWorm extends TamableAnimal implements ISyncMount, ICusto
     private final float prevScale = 0.0F;
     private final LookControl lookHelper;
     private int growthCounter = 0;
-    private Player thrower;
+    private @Nullable Player thrower;
     public DeathwormAITargetItems targetItemsGoal;
 
     public EntityDeathWorm(EntityType<EntityDeathWorm> type, Level worldIn) {
@@ -117,7 +117,7 @@ public class EntityDeathWorm extends TamableAnimal implements ISyncMount, ICusto
         this.targetSelector.addGoal(2, new OwnerHurtByTargetGoal(this));
         this.targetSelector.addGoal(3, new OwnerHurtTargetGoal(this));
         this.targetSelector.addGoal(4, new HurtByTargetGoal(this));
-        this.targetSelector.addGoal(4, targetItemsGoal = new DeathwormAITargetItems(this, false, false));
+        this.targetSelector.addGoal(4, targetItemsGoal = new DeathwormAITargetItems(this));
         this.targetSelector.addGoal(5, new DeathWormAITarget(this, LivingEntity.class, false, new Predicate<LivingEntity>() {
             @Override
             public boolean apply(@Nullable LivingEntity input) {
@@ -226,7 +226,7 @@ public class EntityDeathWorm extends TamableAnimal implements ISyncMount, ICusto
         }
     }
 
-    public void setExplosive(boolean explosive, Player thrower) {
+    public void setExplosive(final @Nullable Player thrower) {
         this.willExplode = true;
         this.ticksTillExplosion = 60;
         this.thrower = thrower;

--- a/src/main/java/com/github/alexthe666/iceandfire/entity/EntityDragonBase.java
+++ b/src/main/java/com/github/alexthe666/iceandfire/entity/EntityDragonBase.java
@@ -2943,7 +2943,7 @@ public abstract class EntityDragonBase extends TamableAnimal implements IPassabi
         }
     }
 
-    @Override // TODO :: Block collision performance impact (due to the multi-part entity)?
+    @Override // TODO :: Performance impact (due to Entity#collideBoundingBox)
     public @NotNull Vec3 handleRelativeFrictionAndCalculateMovement(@NotNull Vec3 pDeltaMovement, float pFriction) {
         if (this.moveControl instanceof IafDragonFlightManager.PlayerFlightMoveHelper)
             return pDeltaMovement;

--- a/src/main/java/com/github/alexthe666/iceandfire/entity/EntityHippogryph.java
+++ b/src/main/java/com/github/alexthe666/iceandfire/entity/EntityHippogryph.java
@@ -187,7 +187,7 @@ public class EntityHippogryph extends TamableAnimal implements ISyncMount, IAnim
         this.targetSelector.addGoal(1, new OwnerHurtByTargetGoal(this));
         this.targetSelector.addGoal(2, new OwnerHurtTargetGoal(this));
         this.targetSelector.addGoal(3, new HurtByTargetGoal(this));
-        this.targetSelector.addGoal(4, new HippogryphAITargetItems(this, false));
+        this.targetSelector.addGoal(4, new HippogryphAITargetItems(this, false, false));
         this.targetSelector.addGoal(5, new HippogryphAITarget(this, LivingEntity.class, false, new Predicate<Entity>() {
             @Override
             public boolean apply(@Nullable Entity entity) {

--- a/src/main/java/com/github/alexthe666/iceandfire/entity/EntityMutlipartPart.java
+++ b/src/main/java/com/github/alexthe666/iceandfire/entity/EntityMutlipartPart.java
@@ -130,7 +130,6 @@ public abstract class EntityMutlipartPart extends Entity {
         wasTouchingWater = false;
         if (this.tickCount > 10) {
             Entity parent = getParent();
-            refreshDimensions();
             if (parent != null && !level.isClientSide) {
                 float renderYawOffset = parent.getYRot();
                 if (parent instanceof LivingEntity) {

--- a/src/main/java/com/github/alexthe666/iceandfire/entity/EntityMyrmexBase.java
+++ b/src/main/java/com/github/alexthe666/iceandfire/entity/EntityMyrmexBase.java
@@ -598,12 +598,16 @@ public abstract class EntityMyrmexBase extends Animal implements IAnimatedEntity
     }
 
     public boolean isInHive() {
-        if (getHive() != null) {
-            for (BlockPos pos : getHive().getAllRooms()) {
-                if (isCloseEnoughToTarget(MyrmexHive.getGroundedPos(level, pos), 50))
+        MyrmexHive hive = getHive();
+
+        if (hive != null) {
+            for (BlockPos roomPosition : hive.getAllRooms()) {
+                if (isCloseEnoughToTarget(roomPosition, 16 * 16)) {
                     return true;
+                }
             }
         }
+
         return false;
     }
 

--- a/src/main/java/com/github/alexthe666/iceandfire/entity/EntityMyrmexQueen.java
+++ b/src/main/java/com/github/alexthe666/iceandfire/entity/EntityMyrmexQueen.java
@@ -248,20 +248,6 @@ public class EntityMyrmexQueen extends EntityMyrmexBase {
 
     }
 
-    public void fall(float distance, float damageMultiplier) {
-    }
-
-    @Override
-    public boolean isInHive() {
-        if (getHive() != null) {
-            for (BlockPos pos : getHive().getAllRooms()) {
-                if (isCloseEnoughToTarget(MyrmexHive.getGroundedPos(level, pos), 300))
-                    return true;
-            }
-        }
-        return false;
-    }
-
     @Override
     public boolean shouldMoveThroughHive() {
         return false;

--- a/src/main/java/com/github/alexthe666/iceandfire/entity/EntityPixie.java
+++ b/src/main/java/com/github/alexthe666/iceandfire/entity/EntityPixie.java
@@ -257,7 +257,7 @@ public class EntityPixie extends TamableAnimal {
     protected void registerGoals() {
         this.goalSelector.addGoal(0, new FloatGoal(this));
         this.goalSelector.addGoal(1, new PixieAIFollowOwner(this, 1.0D, 2.0F, 4.0F));
-        this.goalSelector.addGoal(2, new PixieAIPickupItem(this, false));
+        this.goalSelector.addGoal(2, new PixieAIPickupItem(this, false, false));
         this.goalSelector.addGoal(2, new PixieAIFlee<>(this, Player.class, 10, (Predicate<Player>) entity -> true));
         this.goalSelector.addGoal(2, new PixieAISteal(this, 1.0D));
         this.goalSelector.addGoal(3, new PixieAIMoveRandom(this));

--- a/src/main/java/com/github/alexthe666/iceandfire/entity/EntityPixie.java
+++ b/src/main/java/com/github/alexthe666/iceandfire/entity/EntityPixie.java
@@ -257,7 +257,7 @@ public class EntityPixie extends TamableAnimal {
     protected void registerGoals() {
         this.goalSelector.addGoal(0, new FloatGoal(this));
         this.goalSelector.addGoal(1, new PixieAIFollowOwner(this, 1.0D, 2.0F, 4.0F));
-        this.goalSelector.addGoal(2, new PixieAIPickupItem<>(this, false));
+        this.goalSelector.addGoal(2, new PixieAIPickupItem(this, false));
         this.goalSelector.addGoal(2, new PixieAIFlee<>(this, Player.class, 10, (Predicate<Player>) entity -> true));
         this.goalSelector.addGoal(2, new PixieAISteal(this, 1.0D));
         this.goalSelector.addGoal(3, new PixieAIMoveRandom(this));

--- a/src/main/java/com/github/alexthe666/iceandfire/entity/ai/AmphithereAITargetItems.java
+++ b/src/main/java/com/github/alexthe666/iceandfire/entity/ai/AmphithereAITargetItems.java
@@ -2,98 +2,33 @@ package com.github.alexthe666.iceandfire.entity.ai;
 
 import com.github.alexthe666.iceandfire.datagen.tags.IafItemTags;
 import com.github.alexthe666.iceandfire.entity.EntityAmphithere;
-import com.github.alexthe666.iceandfire.util.IAFMath;
+import com.github.alexthe666.iceandfire.entity.ai.base.PickUpTargetGoal;
 import net.minecraft.sounds.SoundEvents;
-import net.minecraft.world.entity.Entity;
-import net.minecraft.world.entity.Mob;
-import net.minecraft.world.entity.ai.goal.target.TargetGoal;
 import net.minecraft.world.entity.item.ItemEntity;
-import net.minecraft.world.phys.AABB;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
-import java.util.Comparator;
-import java.util.EnumSet;
-import java.util.List;
-import java.util.function.Predicate;
-
-public class AmphithereAITargetItems<T extends ItemEntity> extends TargetGoal {
-    protected final DragonAITargetItems.Sorter theNearestAttackableTargetSorter;
-    protected final Predicate<? super ItemEntity> targetEntitySelector;
-    protected ItemEntity targetEntity;
-    protected final int targetChance;
-    @Nonnull
-    private List<ItemEntity> list = IAFMath.emptyItemEntityList;
-
-    public AmphithereAITargetItems(Mob creature, boolean checkSight) {
-        this(creature, checkSight, false);
-    }
-
-    public AmphithereAITargetItems(Mob creature, boolean checkSight, boolean onlyNearby) {
-        this(creature, 20, checkSight, onlyNearby, null);
-    }
-
-    public AmphithereAITargetItems(Mob creature, int chance, boolean checkSight, boolean onlyNearby, @Nullable final Predicate<? super T> targetSelector) {
-        super(creature, checkSight, onlyNearby);
-        this.theNearestAttackableTargetSorter = new DragonAITargetItems.Sorter(creature);
-        this.targetChance = chance;
-        this.targetEntitySelector = (Predicate<ItemEntity>) item -> item != null && !item.getItem().isEmpty() && item.getItem().is(IafItemTags.HEAL_AMPITHERE);
-        this.setFlags(EnumSet.of(Flag.TARGET));
+public class AmphithereAITargetItems extends PickUpTargetGoal<EntityAmphithere, ItemEntity> {
+    public AmphithereAITargetItems(final EntityAmphithere ampithere) {
+        super(ampithere, false, false, item -> item.getItem().is(IafItemTags.HEAL_AMPITHERE), 0.2);
     }
 
     @Override
     public boolean canUse() {
-        if (this.targetChance > 0 && this.mob.getRandom().nextInt(this.targetChance) != 0) {
-            return false;
-        }
-        if (!((EntityAmphithere) this.mob).canMove()) {
-            list = IAFMath.emptyItemEntityList;
+        if (!getMob().canMove() || mob.getHealth() >= mob.getMaxHealth()) {
             return false;
         }
 
-        // If the target entity already is what we want skip AABB
-        if (targetEntitySelector.test(this.targetEntity)) {
-            return true;
-        }
-
-        if (this.mob.level.getGameTime() % 4 == 0) // only update the list every 4 ticks
-            list = this.mob.level.getEntitiesOfClass(ItemEntity.class, this.getTargetableArea(this.getFollowDistance()), this.targetEntitySelector);
-
-        if (list.isEmpty())
-            return false;
-
-        list.sort(this.theNearestAttackableTargetSorter);
-        this.targetEntity = list.get(0);
-        return true;
-    }
-
-    protected AABB getTargetableArea(double targetDistance) {
-        return this.mob.getBoundingBox().inflate(targetDistance, 4.0D, targetDistance);
-    }
-
-    @Override
-    public void start() {
-        this.mob.getNavigation().moveTo(this.targetEntity.getX(), this.targetEntity.getY(), this.targetEntity.getZ(), 1);
-        super.start();
-    }
-
-    @Override
-    public void stop() {
-        this.targetEntity = null;
-        super.stop();
+        return super.canUse();
     }
 
     @Override
     public void tick() {
         super.tick();
-        if (this.targetEntity == null || !this.targetEntity.isAlive()) {
-            this.stop();
-        }
-        if (this.targetEntity != null && this.targetEntity.isAlive() && this.mob.distanceToSqr(this.targetEntity) < 1) {
-            EntityAmphithere hippo = (EntityAmphithere) this.mob;
-            this.targetEntity.getItem().shrink(1);
-            this.mob.playSound(SoundEvents.GENERIC_EAT, 1, 1);
-            hippo.heal(5);
+
+        if (currentTarget != null && mob.distanceToSqr(currentTarget) < 1) {
+            EntityAmphithere ampithere = getMob();
+            ampithere.playSound(SoundEvents.GENERIC_EAT, 1, 1);
+            ampithere.heal(5);
+            currentTarget.getItem().shrink(1);
             stop();
         }
     }
@@ -103,18 +38,17 @@ public class AmphithereAITargetItems<T extends ItemEntity> extends TargetGoal {
         return !this.mob.getNavigation().isDone();
     }
 
-    public static class Sorter implements Comparator<Entity> {
-        private final Entity theEntity;
-
-        public Sorter(Entity theEntityIn) {
-            this.theEntity = theEntityIn;
+    @Override
+    protected void setMovement() {
+        if (currentTarget == null) {
+            return;
         }
 
-        @Override
-        public int compare(Entity p_compare_1_, Entity p_compare_2_) {
-            final double d0 = this.theEntity.distanceToSqr(p_compare_1_);
-            final double d1 = this.theEntity.distanceToSqr(p_compare_2_);
-            return Double.compare(d0, d1);
-        }
+        mob.getNavigation().moveTo(currentTarget, 1);
+    }
+
+    @Override
+    protected double getSearchRange() {
+        return getFollowDistance();
     }
 }

--- a/src/main/java/com/github/alexthe666/iceandfire/entity/ai/CockatriceAITargetItems.java
+++ b/src/main/java/com/github/alexthe666/iceandfire/entity/ai/CockatriceAITargetItems.java
@@ -2,88 +2,36 @@ package com.github.alexthe666.iceandfire.entity.ai;
 
 import com.github.alexthe666.iceandfire.datagen.tags.IafItemTags;
 import com.github.alexthe666.iceandfire.entity.EntityCockatrice;
-import com.github.alexthe666.iceandfire.util.IAFMath;
+import com.github.alexthe666.iceandfire.entity.ai.base.PickUpTargetGoal;
 import net.minecraft.sounds.SoundEvents;
-import net.minecraft.world.entity.ai.goal.target.TargetGoal;
 import net.minecraft.world.entity.item.ItemEntity;
-import net.minecraft.world.phys.AABB;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
-import java.util.List;
-import java.util.function.Predicate;
-
-public class CockatriceAITargetItems<T extends ItemEntity> extends TargetGoal {
-
-    protected final DragonAITargetItems.Sorter theNearestAttackableTargetSorter;
-    protected final Predicate<? super ItemEntity> targetEntitySelector;
-    protected ItemEntity targetEntity;
-    protected final int targetChance;
-    @Nonnull
-    private List<ItemEntity> list = IAFMath.emptyItemEntityList;
-
-    public CockatriceAITargetItems(EntityCockatrice creature, boolean checkSight) {
-        this(creature, checkSight, false);
-    }
-
-    public CockatriceAITargetItems(EntityCockatrice creature, boolean checkSight, boolean onlyNearby) {
-        this(creature, 10, checkSight, onlyNearby, null);
-    }
-
-    public CockatriceAITargetItems(EntityCockatrice creature, int chance, boolean checkSight, boolean onlyNearby, @Nullable final Predicate<? super T> targetSelector) {
-        super(creature, checkSight, onlyNearby);
-        this.theNearestAttackableTargetSorter = new DragonAITargetItems.Sorter(creature);
-        this.targetChance = chance;
-        this.targetEntitySelector = (Predicate<ItemEntity>) item -> item != null && !item.getItem().isEmpty() && item.getItem().is(IafItemTags.HEAL_COCKATRICE);
+public class CockatriceAITargetItems extends PickUpTargetGoal<EntityCockatrice, ItemEntity> {
+    public CockatriceAITargetItems(EntityCockatrice creature, boolean mustSee, boolean mustReach) {
+        super(creature, mustSee, mustReach, item -> item.getItem().is(IafItemTags.HEAL_COCKATRICE), 0.1);
     }
 
     @Override
     public boolean canUse() {
+        EntityCockatrice cockatrice = getMob();
 
-        if (this.targetChance > 0 && this.mob.getRandom().nextInt(this.targetChance) != 0) {
+        if (!cockatrice.canMove() || cockatrice.getHealth() >= cockatrice.getMaxHealth()) {
             return false;
         }
 
-        if ((!((EntityCockatrice) this.mob).canMove()) || this.mob.getHealth() >= this.mob.getMaxHealth()) {
-            list = IAFMath.emptyItemEntityList;
-            return false;
-        }
-
-        if (this.mob.level.getGameTime() % 4 == 0) // only update the list every 4 ticks
-            list = this.mob.level.getEntitiesOfClass(ItemEntity.class,
-                this.getTargetableArea(this.getFollowDistance()), this.targetEntitySelector);
-
-        if (list.isEmpty()) {
-            return false;
-        } else {
-            list.sort(this.theNearestAttackableTargetSorter);
-            this.targetEntity = list.get(0);
-            return true;
-        }
-    }
-
-    protected AABB getTargetableArea(double targetDistance) {
-        return this.mob.getBoundingBox().inflate(targetDistance, 4.0D, targetDistance);
-    }
-
-    @Override
-    public void start() {
-        this.mob.getNavigation().moveTo(this.targetEntity.getX(), this.targetEntity.getY(),
-            this.targetEntity.getZ(), 1);
-        super.start();
+        return super.canUse();
     }
 
     @Override
     public void tick() {
         super.tick();
-        if (this.targetEntity == null || !this.targetEntity.isAlive()) {
-            this.stop();
-        } else if (this.mob.distanceToSqr(this.targetEntity) < 1) {
-            EntityCockatrice cockatrice = (EntityCockatrice) this.mob;
-            this.targetEntity.getItem().shrink(1);
-            this.mob.playSound(SoundEvents.GENERIC_EAT, 1, 1);
+
+        if (currentTarget != null && mob.distanceToSqr(currentTarget) < 1) {
+            EntityCockatrice cockatrice = getMob();
+            cockatrice.playSound(SoundEvents.GENERIC_EAT, 1, 1);
             cockatrice.heal(8);
             cockatrice.setAnimation(EntityCockatrice.ANIMATION_EAT);
+            currentTarget.getItem().shrink(1);
             stop();
         }
     }
@@ -93,4 +41,17 @@ public class CockatriceAITargetItems<T extends ItemEntity> extends TargetGoal {
         return !this.mob.getNavigation().isDone();
     }
 
+    @Override
+    protected void setMovement() {
+        if (currentTarget == null) {
+            return;
+        }
+
+        mob.getNavigation().moveTo(currentTarget, 1);
+    }
+
+    @Override
+    protected double getSearchRange() {
+        return getFollowDistance();
+    }
 }

--- a/src/main/java/com/github/alexthe666/iceandfire/entity/ai/DeathWormAIGetInSand.java
+++ b/src/main/java/com/github/alexthe666/iceandfire/entity/ai/DeathWormAIGetInSand.java
@@ -29,7 +29,7 @@ public class DeathWormAIGetInSand extends Goal {
 
     @Override
     public boolean canUse() {
-        if (creature.isVehicle() || creature.isInSand() || creature.getTarget() != null && !creature.getTarget().isInWater() || creature.targetItemsGoal.targetEntity != null) {
+        if (creature.isVehicle() || creature.isInSand() || creature.getTarget() != null && !creature.getTarget().isInWater() || creature.targetItemsGoal.hasCurrentTarget()) {
             return false;
         } else {
             Vec3 Vector3d = this.findPossibleShelter();

--- a/src/main/java/com/github/alexthe666/iceandfire/entity/ai/DeathwormAITargetItems.java
+++ b/src/main/java/com/github/alexthe666/iceandfire/entity/ai/DeathwormAITargetItems.java
@@ -5,6 +5,7 @@ import com.github.alexthe666.iceandfire.entity.EntityDeathWorm;
 import com.github.alexthe666.iceandfire.entity.ai.base.PickUpTargetGoal;
 import net.minecraft.sounds.SoundEvents;
 import net.minecraft.tags.BlockTags;
+import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.item.ItemEntity;
 import net.minecraft.world.entity.player.Player;
 
@@ -27,10 +28,11 @@ public class DeathwormAITargetItems extends PickUpTargetGoal<EntityDeathWorm, It
         }
     }
 
-    @Override // FIXME :: Test
+    @Override
     public boolean canContinueToUse() {
         if (currentTarget != null) {
-            if (mob.getTeam() == currentTarget.getTeam()) {
+            Entity thrower = currentTarget.getThrowingEntity();
+            if (/* Can be null */ thrower != null && thrower.isAlliedTo(mob)) {
                 return false;
             } else {
                 double distance = this.getFollowDistance();

--- a/src/main/java/com/github/alexthe666/iceandfire/entity/ai/DeathwormAITargetItems.java
+++ b/src/main/java/com/github/alexthe666/iceandfire/entity/ai/DeathwormAITargetItems.java
@@ -1,125 +1,61 @@
 package com.github.alexthe666.iceandfire.entity.ai;
 
+import com.github.alexthe666.iceandfire.datagen.tags.IafItemTags;
 import com.github.alexthe666.iceandfire.entity.EntityDeathWorm;
-import com.github.alexthe666.iceandfire.util.IAFMath;
+import com.github.alexthe666.iceandfire.entity.ai.base.PickUpTargetGoal;
 import net.minecraft.sounds.SoundEvents;
 import net.minecraft.tags.BlockTags;
-import net.minecraft.world.entity.Entity;
-import net.minecraft.world.entity.ai.goal.target.TargetGoal;
 import net.minecraft.world.entity.item.ItemEntity;
 import net.minecraft.world.entity.player.Player;
-import net.minecraft.world.level.block.Blocks;
-import net.minecraft.world.phys.AABB;
-import net.minecraft.world.scores.Team;
 
-import javax.annotation.Nullable;
-import java.util.EnumSet;
-import java.util.List;
-import java.util.function.Predicate;
-
-public class DeathwormAITargetItems<T extends ItemEntity> extends TargetGoal {
-
-    protected final DragonAITargetItems.Sorter theNearestAttackableTargetSorter;
-    protected final Predicate<? super ItemEntity> targetEntitySelector;
-    protected final int targetChance;
-    private final EntityDeathWorm worm;
-    protected ItemEntity targetEntity;
-    private final List<ItemEntity> list = IAFMath.emptyItemEntityList;
-
-    public DeathwormAITargetItems(EntityDeathWorm creature, boolean checkSight) {
-        this(creature, checkSight, false);
-    }
-
-    public DeathwormAITargetItems(EntityDeathWorm creature, boolean checkSight, boolean onlyNearby) {
-        this(creature, 10, checkSight, onlyNearby, null);
-    }
-
-    public DeathwormAITargetItems(EntityDeathWorm creature, int chance, boolean checkSight, boolean onlyNearby,
-                                  @Nullable final Predicate<? super T> targetSelector) {
-        super(creature, checkSight, onlyNearby);
-        this.worm = creature;
-        this.targetChance = chance;
-        this.theNearestAttackableTargetSorter = new DragonAITargetItems.Sorter(creature);
-        this.targetEntitySelector = new Predicate<ItemEntity>() {
-            @Override
-            public boolean test(ItemEntity item) {
-                return item != null && !item.getItem().isEmpty() && item.getItem().getItem() == Blocks.TNT.asItem() &&
-                    item.level.getBlockState(item.blockPosition().below()).is(BlockTags.SAND);
-            }
-        };
-        this.setFlags(EnumSet.of(Flag.TARGET));
-
-    }
-
-    @Override
-    public boolean canUse() {
-        if (this.targetChance > 0 && this.mob.getRandom().nextInt(this.targetChance) != 0) {
-            return false;
-        }
-        List<ItemEntity> list = this.mob.level.getEntitiesOfClass(ItemEntity.class,
-            this.getTargetableArea(this.getFollowDistance()), this.targetEntitySelector);
-        if (list.isEmpty()) {
-            return false;
-        } else {
-            list.sort(this.theNearestAttackableTargetSorter);
-            this.targetEntity = list.get(0);
-            return true;
-        }
-    }
-
-    protected AABB getTargetableArea(double targetDistance) {
-        return this.mob.getBoundingBox().inflate(targetDistance, 4.0D, targetDistance);
-    }
-
-    @Override
-    public void start() {
-        this.mob.getNavigation().moveTo(this.targetEntity.getX(), this.targetEntity.getY(),
-            this.targetEntity.getZ(), 1);
-        super.start();
-    }
-
-    @Override
-    public boolean canContinueToUse() {
-        Entity itemTarget = targetEntity;
-
-        if (itemTarget == null) {
-            return false;
-        } else if (!itemTarget.isAlive()) {
-            return false;
-        } else {
-            Team team = this.mob.getTeam();
-            Team team1 = itemTarget.getTeam();
-            if (team != null && team1 == team) {
-                return false;
-            } else {
-                double d0 = this.getFollowDistance();
-                return !(this.mob.distanceToSqr(itemTarget) > d0 * d0);
-            }
-        }
+public class DeathwormAITargetItems extends PickUpTargetGoal<EntityDeathWorm, ItemEntity> {
+    public DeathwormAITargetItems(EntityDeathWorm creature) {
+        super(creature, false, false, DeathwormAITargetItems::isItemOnSand, 0.1);
     }
 
     @Override
     public void tick() {
         super.tick();
-        if (this.targetEntity == null || !this.targetEntity.isAlive()) {
-            this.stop();
-        } else if (this.mob.distanceToSqr(this.targetEntity) < 1) {
-            EntityDeathWorm deathWorm = (EntityDeathWorm) this.mob;
-            this.targetEntity.getItem().shrink(1);
-            this.mob.playSound(SoundEvents.GENERIC_EAT, 1, 1);
-            deathWorm.setAnimation(EntityDeathWorm.ANIMATION_BITE);
-            Player thrower = null;
-            if (this.targetEntity.getOwner() != null)
-                thrower = this.targetEntity.level.getPlayerByUUID(this.targetEntity.getOwner());
-            deathWorm.setExplosive(true, thrower);
+
+        if (currentTarget != null && mob.distanceToSqr(currentTarget) < 1) {
+            EntityDeathWorm worm = getMob();
+            worm.playSound(SoundEvents.GENERIC_EAT, 1, 1);
+            worm.setAnimation(EntityDeathWorm.ANIMATION_BITE);
+            worm.setExplosive(currentTarget.getThrowingEntity() instanceof Player player ? player : null);
+            currentTarget.getItem().shrink(1);
             stop();
         }
-
-        if (worm.getNavigation().isDone()) {
-            worm.getNavigation().moveTo(targetEntity, 1.0F);
-        }
-
     }
 
+    @Override // FIXME :: Test
+    public boolean canContinueToUse() {
+        if (currentTarget != null) {
+            if (mob.getTeam() == currentTarget.getTeam()) {
+                return false;
+            } else {
+                double distance = this.getFollowDistance();
+                return !(mob.distanceToSqr(currentTarget) > distance * distance);
+            }
+        }
 
+        return true;
+    }
+
+    @Override
+    protected void setMovement() {
+        if (currentTarget == null) {
+            return;
+        }
+
+        mob.getNavigation().moveTo(currentTarget, 1);
+    }
+
+    @Override
+    protected double getSearchRange() {
+        return getFollowDistance();
+    }
+
+    private static boolean isItemOnSand(final ItemEntity itemEntity) {
+        return itemEntity.getItem().is(IafItemTags.TNT) && itemEntity.getLevel().getBlockState(itemEntity.blockPosition().below()).is(BlockTags.SAND);
+    }
 }

--- a/src/main/java/com/github/alexthe666/iceandfire/entity/ai/DragonAITargetItems.java
+++ b/src/main/java/com/github/alexthe666/iceandfire/entity/ai/DragonAITargetItems.java
@@ -2,139 +2,87 @@ package com.github.alexthe666.iceandfire.entity.ai;
 
 import com.github.alexthe666.iceandfire.api.FoodUtils;
 import com.github.alexthe666.iceandfire.entity.EntityDragonBase;
-import com.github.alexthe666.iceandfire.entity.EntityIceDragon;
-import com.github.alexthe666.iceandfire.util.IAFMath;
+import com.github.alexthe666.iceandfire.entity.ai.base.PickUpTargetGoal;
 import net.minecraft.sounds.SoundEvents;
-import net.minecraft.world.entity.Entity;
-import net.minecraft.world.entity.ai.goal.target.TargetGoal;
 import net.minecraft.world.entity.item.ItemEntity;
-import net.minecraft.world.phys.AABB;
+import net.minecraft.world.item.ItemStack;
 
-import javax.annotation.Nonnull;
-import java.util.Comparator;
-import java.util.EnumSet;
-import java.util.List;
-import java.util.function.Predicate;
+public class DragonAITargetItems extends PickUpTargetGoal<EntityDragonBase, ItemEntity> {
+    private final boolean checkHunger;
+    private final boolean canEatFish;
 
-public class DragonAITargetItems<T extends ItemEntity> extends TargetGoal {
-    protected final DragonAITargetItems.Sorter theNearestAttackableTargetSorter;
-    protected final Predicate<? super ItemEntity> targetEntitySelector;
-    private final int targetChance;
-    private final boolean prioritizeItems;
-    private final boolean isIce;
-
-    protected ItemEntity targetEntity;
-
-    @Nonnull
-    private List<ItemEntity> list = IAFMath.emptyItemEntityList;
-
-    public DragonAITargetItems(EntityDragonBase creature, boolean checkSight) {
-        this(creature, 20, checkSight, false, false);
+    public DragonAITargetItems(final EntityDragonBase creature, boolean checkHunger, boolean canEatFish) {
+        this(creature, 0.2, checkHunger, canEatFish);
     }
 
-    public DragonAITargetItems(EntityDragonBase creature, boolean checkSight, boolean onlyNearby) {
-        this(creature, 20, checkSight, onlyNearby, false);
-    }
-
-    public DragonAITargetItems(EntityDragonBase creature, int chance, boolean checkSight, boolean onlyNearby) {
-        this(creature, chance, checkSight, onlyNearby, false);
-    }
-
-    public DragonAITargetItems(EntityDragonBase creature, int chance, boolean checkSight, boolean onlyNearby, boolean prioritizeItems) {
-        super(creature, checkSight, onlyNearby);
-        this.setFlags(EnumSet.of(Flag.TARGET));
-        this.isIce = creature instanceof EntityIceDragon;
-        this.targetChance = chance;
-        this.theNearestAttackableTargetSorter = new DragonAITargetItems.Sorter(creature);
-        this.setFlags(EnumSet.of(Flag.MOVE));
-        this.targetEntitySelector = (Predicate<ItemEntity>) item -> item != null && !item.getItem().isEmpty() && FoodUtils.getFoodPoints(item.getItem(), true, isIce) > 0;
-        this.prioritizeItems = prioritizeItems;
+    public DragonAITargetItems(final EntityDragonBase dragon, double chance, boolean checkHunger, boolean canEatFish) {
+        super(dragon, false, false, item -> FoodUtils.getFoodPoints(dragon, item.getItem(), true, canEatFish) > 0, chance);
+        this.checkHunger = checkHunger;
+        this.canEatFish = canEatFish;
     }
 
     @Override
     public boolean canUse() {
-        final EntityDragonBase dragon = (EntityDragonBase) this.mob;
+        final EntityDragonBase dragon = getMob();
 
-        if (prioritizeItems && dragon.getHunger() >= 60) {
+        if (checkHunger && dragon.getHunger() >= 60 || dragon.getHunger() >= EntityDragonBase.MAX_HUNGER || !dragon.canMove()) {
             return false;
         }
 
-        if (dragon.getHunger() >= 100 || !dragon.canMove() || (this.targetChance > 0 && this.mob.getRandom().nextInt(10) != 0)) {
-            list = IAFMath.emptyItemEntityList;
-            return false;
-        } else {
-            return updateList();
-        }
-    }
-
-    private boolean updateList() {
-        if (this.mob.level.getGameTime() % 4 == 0) // only update the list every 4 ticks
-            list = this.mob.level.getEntitiesOfClass(ItemEntity.class,
-                    this.getTargetableArea(this.getFollowDistance()), this.targetEntitySelector);
-
-        if (list.isEmpty()) {
-            return false;
-        } else {
-            list.sort(this.theNearestAttackableTargetSorter);
-            this.targetEntity = list.get(0);
-            return true;
-        }
-    }
-
-    protected AABB getTargetableArea(double targetDistance) {
-        return this.mob.getBoundingBox().inflate(targetDistance, 4.0D, targetDistance);
-    }
-
-    @Override
-    public void start() {
-        this.mob.getNavigation().moveTo(this.targetEntity.getX(), this.targetEntity.getY(),
-            this.targetEntity.getZ(), 1);
-        super.start();
+        return super.canUse();
     }
 
     @Override
     public void tick() {
         super.tick();
-        if (this.targetEntity == null || !this.targetEntity.isAlive()) {
-            this.stop();
-        } else if (this.mob.distanceToSqr(this.targetEntity) < this.mob.getBbWidth() * 2 + this.mob.getBbHeight() / 2 || (this.mob instanceof EntityDragonBase dragon && dragon.getHeadPosition().distanceToSqr(this.targetEntity.position()) < this.mob.getBbHeight())) {
-            this.mob.playSound(SoundEvents.GENERIC_EAT, 1, 1);
-            final int hunger = FoodUtils.getFoodPoints(this.targetEntity.getItem(), true, isIce);
-            final EntityDragonBase dragon = ((EntityDragonBase) this.mob);
-            dragon.setHunger(Math.min(100, dragon.getHunger() + hunger));
-            dragon.eatFoodBonus(this.targetEntity.getItem());
-            this.mob.setHealth(Math.min(this.mob.getMaxHealth(), (int) (this.mob.getHealth() + FoodUtils.getFoodPoints(this.targetEntity.getItem(), true, isIce))));
+
+        if (currentTarget == null) {
+            return;
+        }
+
+        EntityDragonBase dragon = getMob();
+
+        boolean canReachVertical = dragon.distanceToSqr(currentTarget) < dragon.getBbWidth() * 2 + dragon.getBbHeight() / 2;
+        boolean canReachHorizontal = dragon.getHeadPosition().distanceToSqr(currentTarget.position()) < dragon.getBbHeight();
+
+        if (canReachVertical || canReachHorizontal) {
+            ItemStack stack = currentTarget.getItem();
+            int hunger = FoodUtils.getFoodPoints(dragon, stack, true, canEatFish);
+
+            dragon.playSound(SoundEvents.GENERIC_EAT, 1, 1);
+            dragon.setHunger(Math.min(EntityDragonBase.MAX_HUNGER, dragon.getHunger() + hunger));
+            dragon.applyFoodEffects(stack);
+            dragon.setHealth(Math.min(this.mob.getMaxHealth(), (int) (this.mob.getHealth() + hunger)));
+
             if (EntityDragonBase.ANIMATION_EAT != null) {
                 dragon.setAnimation(EntityDragonBase.ANIMATION_EAT);
             }
+
             for (int i = 0; i < 4; i++) {
-                dragon.spawnItemCrackParticles(this.targetEntity.getItem().getItem());
+                dragon.spawnItemCrackParticles(stack.getItem());
             }
-            this.targetEntity.getItem().shrink(1);
+
+            stack.shrink(1);
             stop();
-        } else {
-            updateList();
         }
     }
 
     @Override
     public boolean canContinueToUse() {
-        return !this.mob.getNavigation().isDone();
+        return !mob.getNavigation().isDone();
     }
 
-    public static class Sorter implements Comparator<Entity> {
-
-        private final Entity theEntity;
-
-        public Sorter(Entity theEntityIn) {
-            this.theEntity = theEntityIn;
+    @Override
+    protected void setMovement() {
+        if (currentTarget == null) {
+            return;
         }
 
-        @Override
-        public int compare(Entity p_compare_1_, Entity p_compare_2_) {
-            final double d0 = this.theEntity.distanceToSqr(p_compare_1_);
-            final double d1 = this.theEntity.distanceToSqr(p_compare_2_);
-            return Double.compare(d0, d1);
-        }
+        mob.getNavigation().moveTo(currentTarget, 1);
+    }
+
+    @Override
+    protected double getSearchRange() {
+        return getFollowDistance();
     }
 }

--- a/src/main/java/com/github/alexthe666/iceandfire/entity/ai/HippogryphAITargetItems.java
+++ b/src/main/java/com/github/alexthe666/iceandfire/entity/ai/HippogryphAITargetItems.java
@@ -2,121 +2,70 @@ package com.github.alexthe666.iceandfire.entity.ai;
 
 import com.github.alexthe666.iceandfire.datagen.tags.IafItemTags;
 import com.github.alexthe666.iceandfire.entity.EntityHippogryph;
-import com.github.alexthe666.iceandfire.entity.util.EntityUtil;
-import com.github.alexthe666.iceandfire.util.IAFMath;
+import com.github.alexthe666.iceandfire.entity.ai.base.PickUpTargetGoal;
 import net.minecraft.sounds.SoundEvents;
 import net.minecraft.world.entity.Entity;
-import net.minecraft.world.entity.Mob;
-import net.minecraft.world.entity.ai.goal.target.TargetGoal;
 import net.minecraft.world.entity.item.ItemEntity;
 import net.minecraft.world.entity.player.Player;
-import net.minecraft.world.phys.AABB;
-import org.jetbrains.annotations.Nullable;
 
-import java.util.Collections;
-import java.util.List;
-import java.util.function.Predicate;
-
-public class HippogryphAITargetItems extends TargetGoal {
-    protected final Predicate<? super ItemEntity> targetEntitySelector;
-    protected @Nullable ItemEntity targetEntity;
-    protected final int targetChance;
-    private List<ItemEntity> list = IAFMath.emptyItemEntityList;
-
-    public HippogryphAITargetItems(Mob creature, boolean checkSight) {
-        this(creature, checkSight, false);
-    }
-
-    public HippogryphAITargetItems(Mob creature, boolean checkSight, boolean onlyNearby) {
-        this(creature, 20, checkSight, onlyNearby);
-    }
-
-    public HippogryphAITargetItems(Mob creature, int chance, boolean checkSight, boolean onlyNearby) {
-        super(creature, checkSight, onlyNearby);
-        this.targetChance = chance;
-        this.targetEntitySelector = (Predicate<ItemEntity>) item -> item != null && !item.getItem().isEmpty() && item.getItem().is(IafItemTags.TAME_HIPPOGRYPH);
+public class HippogryphAITargetItems extends PickUpTargetGoal<EntityHippogryph, ItemEntity> {
+    public HippogryphAITargetItems(final EntityHippogryph hippogryph, boolean mustSee, boolean mustReach) {
+        super(hippogryph, mustSee, mustReach, item -> item.getItem().is(IafItemTags.TAME_HIPPOGRYPH));
     }
 
     @Override
     public boolean canUse() {
-        if (this.targetChance > 0 && this.mob.getRandom().nextInt(this.targetChance) != 0) {
+        if (!getMob().canMove() || this.mob.getRandom().nextInt(20) != 0) {
             return false;
         }
 
-        if (!((EntityHippogryph) this.mob).canMove()) {
-            list = IAFMath.emptyItemEntityList;
-            return false;
-        }
-
-        updateList(true);
-        return targetEntity != null;
-    }
-
-    private void updateList(boolean forceNew) {
-        list = EntityUtil.updateList(mob, forceNew ? null : list, () -> this.mob.level.getEntitiesOfClass(ItemEntity.class, this.getTargetableArea(this.getFollowDistance()), this.targetEntitySelector));
-        targetEntity = !list.isEmpty() ? list.get(0) : null;
-    }
-
-    protected AABB getTargetableArea(double targetDistance) {
-        return this.mob.getBoundingBox().inflate(targetDistance, 4.0D, targetDistance);
-    }
-
-    @Override
-    public void start() {
-        updateWantedPosition();
-        super.start();
-    }
-
-    private void updateWantedPosition() {
-        if (targetEntity == null) {
-            stop();
-            return;
-        }
-
-        this.mob.getNavigation().moveTo(this.targetEntity.getX(), this.targetEntity.getY(), this.targetEntity.getZ(), 1);
+        return super.canUse();
     }
 
     @Override
     public void tick() {
         super.tick();
 
-        if (this.targetEntity == null || !this.targetEntity.isAlive()) {
-            this.stop();
-        } else if (this.getAttackReachSqr(targetEntity) >= this.mob.distanceToSqr(targetEntity)) {
-            EntityHippogryph hippo = (EntityHippogryph) this.mob;
-            this.targetEntity.getItem().shrink(1);
-            this.mob.playSound(SoundEvents.GENERIC_EAT, 1, 1);
-            hippo.setAnimation(EntityHippogryph.ANIMATION_EAT);
-            hippo.feedings++;
-            hippo.heal(4);
+        if (currentTarget != null && getAttackReachSqr(currentTarget) >= this.mob.distanceToSqr(currentTarget)) {
+            EntityHippogryph hippogryph = getMob();
+            hippogryph.playSound(SoundEvents.GENERIC_EAT, 1, 1);
+            hippogryph.setAnimation(EntityHippogryph.ANIMATION_EAT);
+            hippogryph.feedings++;
+            hippogryph.heal(4);
 
-            if (hippo.feedings > 3 && (hippo.feedings > 7 || hippo.getRandom().nextInt(3) == 0) && !hippo.isTame() && this.targetEntity.getThrowingEntity() instanceof Player player) {
-                    hippo.tame(player);
-                    hippo.setTarget(null);
-                    hippo.setCommand(1);
-                    hippo.setOrderedToSit(true);
+            currentTarget.getItem().shrink(1);
+
+            if (currentTarget.getThrowingEntity() instanceof Player player && hippogryph.feedings > 3 && (hippogryph.feedings > 7 || hippogryph.getRandom().nextInt(3) == 0) && !hippogryph.isTame()) {
+                hippogryph.tame(player);
+                hippogryph.setTarget(null);
+                hippogryph.setCommand(1);
+                hippogryph.setOrderedToSit(true);
             }
 
             stop();
-        } else if (!mob.getMoveControl().hasWanted()) {
-            updateList(false);
-            updateWantedPosition();
         }
     }
 
     @Override
-    public boolean canContinueToUse() {
-        return !this.mob.getNavigation().isDone();
+    protected void setMovement() {
+        if (currentTarget == null) {
+            return;
+        }
+
+        mob.getNavigation().moveTo(currentTarget, 1);
     }
 
-    protected double getAttackReachSqr(Entity attackTarget) {
+    @Override
+    public boolean canContinueToUse() {
+        return !mob.getNavigation().isDone();
+    }
+
+    protected double getAttackReachSqr(final Entity attackTarget) {
         return this.mob.getBbWidth() * 2.0F * this.mob.getBbWidth() * 2.0F + attackTarget.getBbWidth();
     }
 
     @Override
-    public void stop() {
-        super.stop();
-        targetEntity = null;
-        list = Collections.emptyList();
+    protected double getSearchRange() {
+        return getFollowDistance();
     }
 }

--- a/src/main/java/com/github/alexthe666/iceandfire/entity/ai/HippogryphAITargetItems.java
+++ b/src/main/java/com/github/alexthe666/iceandfire/entity/ai/HippogryphAITargetItems.java
@@ -2,6 +2,7 @@ package com.github.alexthe666.iceandfire.entity.ai;
 
 import com.github.alexthe666.iceandfire.datagen.tags.IafItemTags;
 import com.github.alexthe666.iceandfire.entity.EntityHippogryph;
+import com.github.alexthe666.iceandfire.entity.util.EntityUtil;
 import com.github.alexthe666.iceandfire.util.IAFMath;
 import net.minecraft.sounds.SoundEvents;
 import net.minecraft.world.entity.Entity;
@@ -10,19 +11,16 @@ import net.minecraft.world.entity.ai.goal.target.TargetGoal;
 import net.minecraft.world.entity.item.ItemEntity;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.phys.AABB;
+import org.jetbrains.annotations.Nullable;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
-import java.util.Comparator;
+import java.util.Collections;
 import java.util.List;
 import java.util.function.Predicate;
 
-public class HippogryphAITargetItems<T extends ItemEntity> extends TargetGoal {
-    protected final DragonAITargetItems.Sorter theNearestAttackableTargetSorter;
+public class HippogryphAITargetItems extends TargetGoal {
     protected final Predicate<? super ItemEntity> targetEntitySelector;
-    protected ItemEntity targetEntity;
+    protected @Nullable ItemEntity targetEntity;
     protected final int targetChance;
-    @Nonnull
     private List<ItemEntity> list = IAFMath.emptyItemEntityList;
 
     public HippogryphAITargetItems(Mob creature, boolean checkSight) {
@@ -30,12 +28,11 @@ public class HippogryphAITargetItems<T extends ItemEntity> extends TargetGoal {
     }
 
     public HippogryphAITargetItems(Mob creature, boolean checkSight, boolean onlyNearby) {
-        this(creature, 20, checkSight, onlyNearby, null);
+        this(creature, 20, checkSight, onlyNearby);
     }
 
-    public HippogryphAITargetItems(Mob creature, int chance, boolean checkSight, boolean onlyNearby, @Nullable final Predicate<? super T> targetSelector) {
+    public HippogryphAITargetItems(Mob creature, int chance, boolean checkSight, boolean onlyNearby) {
         super(creature, checkSight, onlyNearby);
-        this.theNearestAttackableTargetSorter = new DragonAITargetItems.Sorter(creature);
         this.targetChance = chance;
         this.targetEntitySelector = (Predicate<ItemEntity>) item -> item != null && !item.getItem().isEmpty() && item.getItem().is(IafItemTags.TAME_HIPPOGRYPH);
     }
@@ -45,25 +42,19 @@ public class HippogryphAITargetItems<T extends ItemEntity> extends TargetGoal {
         if (this.targetChance > 0 && this.mob.getRandom().nextInt(this.targetChance) != 0) {
             return false;
         }
+
         if (!((EntityHippogryph) this.mob).canMove()) {
             list = IAFMath.emptyItemEntityList;
             return false;
         }
 
-        return updateList();
+        updateList(true);
+        return targetEntity != null;
     }
 
-    private boolean updateList() {
-        if (this.mob.level.getGameTime() % 4 == 0) // only update the list every 4 ticks
-            list = this.mob.level.getEntitiesOfClass(ItemEntity.class, this.getTargetableArea(this.getFollowDistance()), this.targetEntitySelector);
-
-        if (list.isEmpty()) {
-            return false;
-        } else {
-            list.sort(this.theNearestAttackableTargetSorter);
-            this.targetEntity = list.get(0);
-            return true;
-        }
+    private void updateList(boolean forceNew) {
+        list = EntityUtil.updateList(mob, forceNew ? null : list, () -> this.mob.level.getEntitiesOfClass(ItemEntity.class, this.getTargetableArea(this.getFollowDistance()), this.targetEntitySelector));
+        targetEntity = !list.isEmpty() ? list.get(0) : null;
     }
 
     protected AABB getTargetableArea(double targetDistance) {
@@ -72,13 +63,23 @@ public class HippogryphAITargetItems<T extends ItemEntity> extends TargetGoal {
 
     @Override
     public void start() {
-        this.mob.getNavigation().moveTo(this.targetEntity.getX(), this.targetEntity.getY(), this.targetEntity.getZ(), 1);
+        updateWantedPosition();
         super.start();
+    }
+
+    private void updateWantedPosition() {
+        if (targetEntity == null) {
+            stop();
+            return;
+        }
+
+        this.mob.getNavigation().moveTo(this.targetEntity.getX(), this.targetEntity.getY(), this.targetEntity.getZ(), 1);
     }
 
     @Override
     public void tick() {
         super.tick();
+
         if (this.targetEntity == null || !this.targetEntity.isAlive()) {
             this.stop();
         } else if (this.getAttackReachSqr(targetEntity) >= this.mob.distanceToSqr(targetEntity)) {
@@ -88,15 +89,18 @@ public class HippogryphAITargetItems<T extends ItemEntity> extends TargetGoal {
             hippo.setAnimation(EntityHippogryph.ANIMATION_EAT);
             hippo.feedings++;
             hippo.heal(4);
+
             if (hippo.feedings > 3 && (hippo.feedings > 7 || hippo.getRandom().nextInt(3) == 0) && !hippo.isTame() && this.targetEntity.getThrowingEntity() instanceof Player player) {
                     hippo.tame(player);
                     hippo.setTarget(null);
                     hippo.setCommand(1);
                     hippo.setOrderedToSit(true);
             }
+
             stop();
-        } else {
-            updateList();
+        } else if (!mob.getMoveControl().hasWanted()) {
+            updateList(false);
+            updateWantedPosition();
         }
     }
 
@@ -105,22 +109,14 @@ public class HippogryphAITargetItems<T extends ItemEntity> extends TargetGoal {
         return !this.mob.getNavigation().isDone();
     }
 
-    public static class Sorter implements Comparator<Entity> {
-        private final Entity theEntity;
-
-        public Sorter(Entity theEntityIn) {
-            this.theEntity = theEntityIn;
-        }
-
-        @Override
-        public int compare(Entity p_compare_1_, Entity p_compare_2_) {
-            final double d0 = this.theEntity.distanceToSqr(p_compare_1_);
-            final double d1 = this.theEntity.distanceToSqr(p_compare_2_);
-            return Double.compare(d0, d1);
-        }
-    }
-
     protected double getAttackReachSqr(Entity attackTarget) {
         return this.mob.getBbWidth() * 2.0F * this.mob.getBbWidth() * 2.0F + attackTarget.getBbWidth();
+    }
+
+    @Override
+    public void stop() {
+        super.stop();
+        targetEntity = null;
+        list = Collections.emptyList();
     }
 }

--- a/src/main/java/com/github/alexthe666/iceandfire/entity/ai/HippogryphAITargetItems.java
+++ b/src/main/java/com/github/alexthe666/iceandfire/entity/ai/HippogryphAITargetItems.java
@@ -10,12 +10,12 @@ import net.minecraft.world.entity.player.Player;
 
 public class HippogryphAITargetItems extends PickUpTargetGoal<EntityHippogryph, ItemEntity> {
     public HippogryphAITargetItems(final EntityHippogryph hippogryph, boolean mustSee, boolean mustReach) {
-        super(hippogryph, mustSee, mustReach, item -> item.getItem().is(IafItemTags.TAME_HIPPOGRYPH));
+        super(hippogryph, mustSee, mustReach, item -> item.getItem().is(IafItemTags.TAME_HIPPOGRYPH), 0.2);
     }
 
     @Override
     public boolean canUse() {
-        if (!getMob().canMove() || this.mob.getRandom().nextInt(20) != 0) {
+        if (!getMob().canMove()) {
             return false;
         }
 
@@ -47,6 +47,11 @@ public class HippogryphAITargetItems extends PickUpTargetGoal<EntityHippogryph, 
     }
 
     @Override
+    public boolean canContinueToUse() {
+        return !mob.getNavigation().isDone();
+    }
+
+    @Override
     protected void setMovement() {
         if (currentTarget == null) {
             return;
@@ -56,16 +61,11 @@ public class HippogryphAITargetItems extends PickUpTargetGoal<EntityHippogryph, 
     }
 
     @Override
-    public boolean canContinueToUse() {
-        return !mob.getNavigation().isDone();
+    protected double getSearchRange() {
+        return getFollowDistance();
     }
 
     protected double getAttackReachSqr(final Entity attackTarget) {
         return this.mob.getBbWidth() * 2.0F * this.mob.getBbWidth() * 2.0F + attackTarget.getBbWidth();
-    }
-
-    @Override
-    protected double getSearchRange() {
-        return getFollowDistance();
     }
 }

--- a/src/main/java/com/github/alexthe666/iceandfire/entity/ai/MyrmexAIFindHidingSpot.java
+++ b/src/main/java/com/github/alexthe666/iceandfire/entity/ai/MyrmexAIFindHidingSpot.java
@@ -1,6 +1,7 @@
 package com.github.alexthe666.iceandfire.entity.ai;
 
 import com.github.alexthe666.iceandfire.entity.EntityMyrmexSentinel;
+import com.github.alexthe666.iceandfire.entity.util.EntityUtil;
 import net.minecraft.core.BlockPos;
 import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.ai.goal.Goal;
@@ -15,49 +16,44 @@ import java.util.function.Predicate;
 
 public class MyrmexAIFindHidingSpot extends Goal {
     private static final int RADIUS = 32;
-    protected final DragonAITargetItems.Sorter theNearestAttackableTargetSorter;
+    protected final EntityUtil.Sorter sorter;
     protected final Predicate<? super Entity> targetEntitySelector;
-    private final EntityMyrmexSentinel myrmex;
+    private final EntityMyrmexSentinel sentinel;
     private BlockPos targetBlock = null;
     private int wanderRadius = RADIUS;
 
-    public MyrmexAIFindHidingSpot(EntityMyrmexSentinel myrmex) {
+    public MyrmexAIFindHidingSpot(final EntityMyrmexSentinel sentinel) {
         super();
-        this.theNearestAttackableTargetSorter = new DragonAITargetItems.Sorter(myrmex);
-        this.targetEntitySelector = new Predicate<Entity>() {
-            @Override
-            public boolean test(Entity myrmex) {
-                return myrmex instanceof EntityMyrmexSentinel;
-            }
-        };
-        this.myrmex = myrmex;
+        this.sorter = new EntityUtil.Sorter(sentinel);
+        this.targetEntitySelector = (Predicate<Entity>) myrmex -> myrmex instanceof EntityMyrmexSentinel;
+        this.sentinel = sentinel;
         this.setFlags(EnumSet.of(Flag.MOVE));
     }
 
     @Override
     public boolean canUse() {
         this.targetBlock = getTargetPosition(wanderRadius);
-        return this.myrmex.canMove() && this.myrmex.getTarget() == null && myrmex.canSeeSky() && !myrmex.isHiding() && myrmex.visibleTicks <= 0;
+        return this.sentinel.canMove() && this.sentinel.getTarget() == null && sentinel.canSeeSky() && !sentinel.isHiding() && sentinel.visibleTicks <= 0;
     }
 
     @Override
     public boolean canContinueToUse() {
-        return !myrmex.shouldEnterHive() && this.myrmex.getTarget() == null && !myrmex.isHiding() && myrmex.visibleTicks <= 0;
+        return !sentinel.shouldEnterHive() && this.sentinel.getTarget() == null && !sentinel.isHiding() && sentinel.visibleTicks <= 0;
     }
 
     @Override
     public void tick() {
        if (targetBlock != null) {
-           this.myrmex.getNavigation().moveTo(this.targetBlock.getX() + 0.5D, this.targetBlock.getY(), this.targetBlock.getZ() + 0.5D, 1D);
-           if (areMyrmexNear(5) || this.myrmex.isOnResin()) {
-               if (this.myrmex.distanceToSqr(Vec3.atCenterOf(this.targetBlock)) < 9) {
+           this.sentinel.getNavigation().moveTo(this.targetBlock.getX() + 0.5D, this.targetBlock.getY(), this.targetBlock.getZ() + 0.5D, 1D);
+           if (areMyrmexNear(5) || this.sentinel.isOnResin()) {
+               if (this.sentinel.distanceToSqr(Vec3.atCenterOf(this.targetBlock)) < 9) {
                    this.wanderRadius += RADIUS;
                    this.targetBlock = getTargetPosition(wanderRadius);
                }
            } else {
-               if (this.myrmex.getTarget() == null && this.myrmex.getTradingPlayer() == null && myrmex.visibleTicks == 0 && this.myrmex.distanceToSqr(Vec3.atCenterOf(this.targetBlock)) < 9) {
-                   myrmex.setHiding(true);
-                   myrmex.getNavigation().stop();
+               if (this.sentinel.getTarget() == null && this.sentinel.getTradingPlayer() == null && sentinel.visibleTicks == 0 && this.sentinel.distanceToSqr(Vec3.atCenterOf(this.targetBlock)) < 9) {
+                   sentinel.setHiding(true);
+                   sentinel.getNavigation().stop();
                }
            }
        }
@@ -71,17 +67,17 @@ public class MyrmexAIFindHidingSpot extends Goal {
     }
 
     protected AABB getTargetableArea(double targetDistance) {
-        return this.myrmex.getBoundingBox().inflate(targetDistance, 14.0D, targetDistance);
+        return this.sentinel.getBoundingBox().inflate(targetDistance, 14.0D, targetDistance);
     }
 
     public BlockPos getTargetPosition(int radius) {
-        final int x = (int) myrmex.getX() + myrmex.getRandom().nextInt(radius * 2) - radius;
-        final int z = (int) myrmex.getZ() + myrmex.getRandom().nextInt(radius * 2) - radius;
-        return myrmex.level.getHeightmapPos(Heightmap.Types.MOTION_BLOCKING_NO_LEAVES, new BlockPos(x, 0, z));
+        final int x = (int) sentinel.getX() + sentinel.getRandom().nextInt(radius * 2) - radius;
+        final int z = (int) sentinel.getZ() + sentinel.getRandom().nextInt(radius * 2) - radius;
+        return sentinel.level.getHeightmapPos(Heightmap.Types.MOTION_BLOCKING_NO_LEAVES, new BlockPos(x, 0, z));
     }
 
     private boolean areMyrmexNear(double distance) {
-        List<Entity> sentinels = this.myrmex.level.getEntities(this.myrmex, this.getTargetableArea(distance), this.targetEntitySelector);
+        List<Entity> sentinels = this.sentinel.level.getEntities(this.sentinel, this.getTargetableArea(distance), this.targetEntitySelector);
         List<Entity> hiddenSentinels = new ArrayList<>();
         for (Entity sentinel : sentinels) {
             if (sentinel instanceof EntityMyrmexSentinel && ((EntityMyrmexSentinel) sentinel).isHiding()) {

--- a/src/main/java/com/github/alexthe666/iceandfire/entity/ai/MyrmexAIFindMate.java
+++ b/src/main/java/com/github/alexthe666/iceandfire/entity/ai/MyrmexAIFindMate.java
@@ -1,7 +1,7 @@
 package com.github.alexthe666.iceandfire.entity.ai;
 
-import com.github.alexthe666.iceandfire.entity.EntityMyrmexBase;
 import com.github.alexthe666.iceandfire.entity.EntityMyrmexRoyal;
+import com.github.alexthe666.iceandfire.entity.util.EntityUtil;
 import com.github.alexthe666.iceandfire.entity.util.MyrmexHive;
 import com.github.alexthe666.iceandfire.util.IAFMath;
 import com.github.alexthe666.iceandfire.world.MyrmexWorldData;
@@ -10,63 +10,54 @@ import net.minecraft.world.entity.ai.goal.target.TargetGoal;
 import net.minecraft.world.phys.AABB;
 
 import javax.annotation.Nonnull;
-import java.util.Comparator;
 import java.util.EnumSet;
 import java.util.List;
 import java.util.function.Predicate;
 
-public class MyrmexAIFindMate<T extends EntityMyrmexBase> extends TargetGoal {
-    protected final DragonAITargetItems.Sorter theNearestAttackableTargetSorter;
-    protected final Predicate<? super Entity> targetEntitySelector;
-    public EntityMyrmexRoyal myrmex;
-    protected EntityMyrmexBase targetEntity;
+public class MyrmexAIFindMate extends TargetGoal {
+    private final EntityUtil.Sorter sorter;
+    private final Predicate<? super Entity> targetEntitySelector;
+    private final EntityMyrmexRoyal royal;
+    private @Nonnull List<Entity> list = IAFMath.emptyEntityList;
 
-    @Nonnull
-    private List<Entity> list = IAFMath.emptyEntityList;
-
-    public MyrmexAIFindMate(EntityMyrmexRoyal myrmex) {
-        super(myrmex, false, false);
-        this.theNearestAttackableTargetSorter = new DragonAITargetItems.Sorter(myrmex);
-        this.targetEntitySelector = new Predicate<Entity>() {
-            @Override
-            public boolean test(Entity myrmex) {
-                return myrmex instanceof EntityMyrmexRoyal && ((EntityMyrmexRoyal) myrmex).getGrowthStage() >= 2;
-            }
-        };
-        this.myrmex = myrmex;
+    public MyrmexAIFindMate(final EntityMyrmexRoyal royal) {
+        super(royal, false, false);
+        this.sorter = new EntityUtil.Sorter(royal);
+        this.targetEntitySelector = (Predicate<Entity>) entity -> entity instanceof EntityMyrmexRoyal otherRoyal && otherRoyal.getGrowthStage() >= 2;
+        this.royal = royal;
         this.setFlags(EnumSet.of(Flag.MOVE));
     }
 
     @Override
     public boolean canUse() {
-        if (!this.myrmex.shouldHaveNormalAI()) {
+        if (!this.royal.shouldHaveNormalAI()) {
             list = IAFMath.emptyEntityList;
             return false;
         }
-        if (!this.myrmex.canMove() || this.myrmex.getTarget() != null || this.myrmex.releaseTicks < 400 || this.myrmex.mate != null) {
+        if (!this.royal.canMove() || this.royal.getTarget() != null || this.royal.releaseTicks < 400 || this.royal.mate != null) {
             list = IAFMath.emptyEntityList;
             return false;
         }
-        MyrmexHive village = this.myrmex.getHive();
+        MyrmexHive village = this.royal.getHive();
         if (village == null) {
-            village = MyrmexWorldData.get(this.myrmex.level).getNearestHive(this.myrmex.blockPosition(), 100);
+            village = MyrmexWorldData.get(this.royal.level).getNearestHive(this.royal.blockPosition(), 100);
         }
-        if (village != null && village.getCenter().distToCenterSqr(this.myrmex.getX(), village.getCenter().getY(), this.myrmex.getZ()) < 2000) {
+        if (village != null && village.getCenter().distToCenterSqr(this.royal.getX(), village.getCenter().getY(), this.royal.getZ()) < 2000) {
             list = IAFMath.emptyEntityList;
             return false;
         }
 
-        if (this.myrmex.level.getGameTime() % 4 == 0) // only update the list every 4 ticks
-            list = this.mob.level.getEntities(myrmex, this.getTargetableArea(100), this.targetEntitySelector);
+        if (this.royal.level.getGameTime() % 4 == 0) // only update the list every 4 ticks
+            list = this.mob.level.getEntities(royal, this.getTargetableArea(100), this.targetEntitySelector);
 
         if (list.isEmpty())
             return false;
 
-        list.sort(this.theNearestAttackableTargetSorter);
+        list.sort(this.sorter);
         for (Entity royal : list) {
-            if (this.myrmex.canMate((EntityMyrmexRoyal) royal)) {
-                this.myrmex.mate = (EntityMyrmexRoyal) royal;
-                this.myrmex.level.broadcastEntityEvent(this.myrmex, (byte) 76);
+            if (this.royal.canMate((EntityMyrmexRoyal) royal)) {
+                this.royal.mate = (EntityMyrmexRoyal) royal;
+                this.royal.level.broadcastEntityEvent(this.royal, (byte) 76);
                 return true;
             }
         }
@@ -80,20 +71,5 @@ public class MyrmexAIFindMate<T extends EntityMyrmexBase> extends TargetGoal {
     @Override
     public boolean canContinueToUse() {
         return false;
-    }
-
-    public static class Sorter implements Comparator<Entity> {
-        private final Entity theEntity;
-
-        public Sorter(EntityMyrmexBase theEntityIn) {
-            this.theEntity = theEntityIn;
-        }
-
-        @Override
-        public int compare(Entity p_compare_1_, Entity p_compare_2_) {
-            final double d0 = this.theEntity.distanceToSqr(p_compare_1_);
-            final double d1 = this.theEntity.distanceToSqr(p_compare_2_);
-            return Double.compare(d0, d1);
-        }
     }
 }

--- a/src/main/java/com/github/alexthe666/iceandfire/entity/ai/MyrmexAIForageForItems.java
+++ b/src/main/java/com/github/alexthe666/iceandfire/entity/ai/MyrmexAIForageForItems.java
@@ -1,105 +1,63 @@
 package com.github.alexthe666.iceandfire.entity.ai;
 
 import com.github.alexthe666.iceandfire.entity.EntityMyrmexWorker;
-import com.github.alexthe666.iceandfire.util.IAFMath;
+import com.github.alexthe666.iceandfire.entity.ai.base.PickUpTargetGoal;
 import net.minecraft.world.InteractionHand;
 import net.minecraft.world.entity.Entity;
-import net.minecraft.world.entity.ai.goal.target.TargetGoal;
 import net.minecraft.world.entity.item.ItemEntity;
-import net.minecraft.world.phys.AABB;
 
-import javax.annotation.Nonnull;
-import java.util.Comparator;
 import java.util.EnumSet;
-import java.util.List;
-import java.util.function.Predicate;
 
-public class MyrmexAIForageForItems<T extends ItemEntity> extends TargetGoal {
-    protected final DragonAITargetItems.Sorter theNearestAttackableTargetSorter;
-    protected final Predicate<? super ItemEntity> targetEntitySelector;
-    public EntityMyrmexWorker myrmex;
-    protected ItemEntity targetEntity;
-
-    @Nonnull
-    private List<ItemEntity> list = IAFMath.emptyItemEntityList;
-
-    public MyrmexAIForageForItems(EntityMyrmexWorker myrmex) {
-        super(myrmex, false, false);
-        this.theNearestAttackableTargetSorter = new DragonAITargetItems.Sorter(myrmex);
-        this.targetEntitySelector = new Predicate<ItemEntity>() {
-            @Override
-            public boolean test(ItemEntity item) {
-                return item != null && !item.getItem().isEmpty() && !item.isInWater();
-            }
-        };
-        this.myrmex = myrmex;
+public class MyrmexAIForageForItems extends PickUpTargetGoal<EntityMyrmexWorker, ItemEntity> {
+    public MyrmexAIForageForItems(final EntityMyrmexWorker worker) {
+        super(worker, false, false, item -> !item.isInWater(), 1);
         this.setFlags(EnumSet.of(Flag.MOVE));
     }
 
     @Override
     public boolean canUse() {
-        if (!this.myrmex.canMove() || this.myrmex.holdingSomething() || this.myrmex.shouldEnterHive() || !this.myrmex.keepSearching || this.myrmex.getTarget() != null) {
-            list = IAFMath.emptyItemEntityList;
+        EntityMyrmexWorker worker = getMob();
+
+        if (!worker.canMove() || worker.holdingSomething() || worker.shouldEnterHive() || !worker.keepSearching || worker.getTarget() != null) {
             return false;
         }
 
-        if (this.myrmex.level.getGameTime() % 4 == 0) // only update the list every 4 ticks
-            list = this.mob.level.getEntitiesOfClass(ItemEntity.class, this.getTargetableArea(32), this.targetEntitySelector);
-
-        if (list.isEmpty())
-            return false;
-
-        list.sort(this.theNearestAttackableTargetSorter);
-        this.targetEntity = list.get(0);
-        return true;
-    }
-
-    protected AABB getTargetableArea(double targetDistance) {
-        return this.mob.getBoundingBox().inflate(targetDistance, 5, targetDistance);
-    }
-
-    @Override
-    public void start() {
-        this.mob.getNavigation().moveTo(this.targetEntity.getX(), this.targetEntity.getY(), this.targetEntity.getZ(), 1);
-        super.start();
+        return super.canUse();
     }
 
     @Override
     public void tick() {
         super.tick();
-        if (this.targetEntity == null || (!this.targetEntity.isAlive() || this.targetEntity.isInWater())) {
-            this.stop();
-        } else if (this.mob.distanceToSqr(this.targetEntity) < 8F) {
-            this.myrmex.onPickupItem(targetEntity);
-            this.myrmex.setItemInHand(InteractionHand.MAIN_HAND, this.targetEntity.getItem());
-            this.targetEntity.remove(Entity.RemovalReason.DISCARDED);
-            stop();
-        }
-    }
 
-    @Override
-    public void stop() {
-        this.myrmex.getNavigation().stop();
-        super.stop();
+        if (currentTarget == null || currentTarget.isInWater()) {
+            return;
+        }
+
+       if (mob.distanceToSqr(currentTarget) < 8F) {
+           EntityMyrmexWorker worker = getMob();
+           worker.onPickupItem(currentTarget);
+           worker.setItemInHand(InteractionHand.MAIN_HAND, currentTarget.getItem());
+           worker.remove(Entity.RemovalReason.DISCARDED);
+           stop();
+        }
     }
 
     @Override
     public boolean canContinueToUse() {
-        return !this.mob.getNavigation().isDone() && this.myrmex.getTarget() == null;
+        return !this.mob.getNavigation().isDone() && mob.getTarget() == null;
     }
 
-    public static class Sorter implements Comparator<Entity> {
-        private final Entity theEntity;
-
-        public Sorter(Entity theEntityIn) {
-            this.theEntity = theEntityIn;
+    @Override
+    protected void setMovement() {
+        if (currentTarget == null) {
+            return;
         }
 
-        @Override
-        public int compare(Entity p_compare_1_, Entity p_compare_2_) {
-            final double d0 = this.theEntity.distanceToSqr(p_compare_1_);
-            final double d1 = this.theEntity.distanceToSqr(p_compare_2_);
-            return Double.compare(d0, d1);
-        }
+        mob.getNavigation().moveTo(currentTarget, 1);
+    }
+
+    @Override
+    protected double getSearchRange() {
+        return 32;
     }
 }

--- a/src/main/java/com/github/alexthe666/iceandfire/entity/ai/MyrmexAIForageForItems.java
+++ b/src/main/java/com/github/alexthe666/iceandfire/entity/ai/MyrmexAIForageForItems.java
@@ -30,6 +30,7 @@ public class MyrmexAIForageForItems extends PickUpTargetGoal<EntityMyrmexWorker,
         super.tick();
 
         if (currentTarget == null || currentTarget.isInWater()) {
+            currentTarget = null;
             return;
         }
 
@@ -37,7 +38,7 @@ public class MyrmexAIForageForItems extends PickUpTargetGoal<EntityMyrmexWorker,
            EntityMyrmexWorker worker = getMob();
            worker.onPickupItem(currentTarget);
            worker.setItemInHand(InteractionHand.MAIN_HAND, currentTarget.getItem());
-           worker.remove(Entity.RemovalReason.DISCARDED);
+           currentTarget.remove(Entity.RemovalReason.DISCARDED);
            stop();
         }
     }

--- a/src/main/java/com/github/alexthe666/iceandfire/entity/ai/MyrmexAIPickupBabies.java
+++ b/src/main/java/com/github/alexthe666/iceandfire/entity/ai/MyrmexAIPickupBabies.java
@@ -3,98 +3,59 @@ package com.github.alexthe666.iceandfire.entity.ai;
 import com.github.alexthe666.iceandfire.entity.EntityMyrmexBase;
 import com.github.alexthe666.iceandfire.entity.EntityMyrmexEgg;
 import com.github.alexthe666.iceandfire.entity.EntityMyrmexWorker;
-import com.github.alexthe666.iceandfire.entity.util.EntityUtil;
-import com.github.alexthe666.iceandfire.util.IAFMath;
-import net.minecraft.world.entity.Entity;
+import com.github.alexthe666.iceandfire.entity.ai.base.PickUpTargetGoal;
 import net.minecraft.world.entity.LivingEntity;
-import net.minecraft.world.entity.ai.goal.target.TargetGoal;
-import net.minecraft.world.phys.AABB;
 
-import javax.annotation.Nullable;
-import java.util.Collections;
-import java.util.EnumSet;
-import java.util.List;
-import java.util.function.Predicate;
-
-public class MyrmexAIPickupBabies extends TargetGoal {
-    protected final Predicate<? super LivingEntity> targetEntitySelector;
-    public EntityMyrmexWorker myrmex;
-    protected @Nullable LivingEntity targetEntity;
-
-    private List<LivingEntity> listBabies = IAFMath.emptyLivingEntityList;
-
-    public MyrmexAIPickupBabies(EntityMyrmexWorker myrmex) {
-        super(myrmex, false, false);
-        this.targetEntitySelector = (Predicate<LivingEntity>) toCheck -> isYoungMyrmex(toCheck) || isMyrmexEgg(toCheck);
-        this.myrmex = myrmex;
-        this.setFlags(EnumSet.of(Flag.TARGET));
-    }
-
-    private boolean isYoungMyrmex(final Entity entity) {
-        return entity instanceof EntityMyrmexBase base && base.getGrowthStage() < 2 && !base.isInNursery();
-    }
-
-    private boolean isMyrmexEgg(final Entity entity) {
-        return entity instanceof EntityMyrmexEgg egg && !egg.isInNursery();
+public class MyrmexAIPickupBabies extends PickUpTargetGoal<EntityMyrmexWorker, LivingEntity> {
+    public MyrmexAIPickupBabies(final EntityMyrmexWorker worker) {
+        super(worker, false, false, entity -> isYoungMyrmex(entity) || isMyrmexEgg(entity));
     }
 
     @Override
     public boolean canUse() {
-        if (!this.myrmex.canMove() || this.myrmex.holdingSomething() || !this.myrmex.getNavigation().isDone() || this.myrmex.shouldEnterHive() || !this.myrmex.keepSearching || this.myrmex.holdingBaby()) {
-            listBabies = IAFMath.emptyLivingEntityList;
+        EntityMyrmexWorker worker = getMob();
+
+        if (!worker.canMove() || worker.holdingSomething() || !worker.getNavigation().isDone() || worker.shouldEnterHive() || !worker.keepSearching || worker.holdingBaby()) {
             return false;
         }
 
-        updateList(true);
-        return targetEntity != null;
-    }
-
-    protected AABB getTargetableArea(double targetDistance) {
-        return this.mob.getBoundingBox().inflate(targetDistance, 4.0D, targetDistance);
-    }
-
-    private void updateList(boolean forceNew) {
-        listBabies = EntityUtil.updateList(mob, forceNew ? null : listBabies, () -> this.mob.level.getEntitiesOfClass(LivingEntity.class, this.getTargetableArea(20), this.targetEntitySelector));
-        targetEntity = !listBabies.isEmpty() ? listBabies.get(0) : null;
-    }
-
-    @Override
-    public void start() {
-        updateWantedPosition();
-        super.start();
-    }
-
-    private void updateWantedPosition() {
-        if (targetEntity == null) {
-            stop();
-            return;
-        }
-
-        this.mob.getNavigation().moveTo(this.targetEntity.getX(), this.targetEntity.getY(), this.targetEntity.getZ(), 1);
+        return super.canUse();
     }
 
     @Override
     public void tick() {
         super.tick();
 
-        if (this.targetEntity != null && this.targetEntity.isAlive() && this.mob.distanceToSqr(this.targetEntity) < 2) {
-            this.targetEntity.startRiding(this.myrmex);
+        if (currentTarget != null && mob.distanceToSqr(currentTarget) < 2) {
+            currentTarget.startRiding(getMob());
             stop();
-        } else if (!mob.getMoveControl().hasWanted()) {
-            updateList(false);
-            updateWantedPosition();
         }
     }
 
     @Override
     public boolean canContinueToUse() {
-        return !this.mob.getNavigation().isDone();
+        return !mob.getNavigation().isDone();
     }
 
     @Override
-    public void stop() {
-        super.stop();
-        targetEntity = null;
-        listBabies = Collections.emptyList();
+    protected void setMovement() {
+        if (currentTarget == null) {
+            return;
+        }
+
+        mob.getNavigation().moveTo(currentTarget, 1);
+    }
+
+    @Override
+    protected double getSearchRange() {
+        return 20;
+    }
+
+    private static boolean isYoungMyrmex(final LivingEntity entity) {
+        return entity instanceof EntityMyrmexBase base && base.getGrowthStage() < 2 && !base.isInNursery();
+    }
+
+    private static boolean isMyrmexEgg(final LivingEntity entity) {
+        return entity instanceof EntityMyrmexEgg egg && !egg.isInNursery();
     }
 }

--- a/src/main/java/com/github/alexthe666/iceandfire/entity/ai/MyrmexAIPickupBabies.java
+++ b/src/main/java/com/github/alexthe666/iceandfire/entity/ai/MyrmexAIPickupBabies.java
@@ -3,39 +3,39 @@ package com.github.alexthe666.iceandfire.entity.ai;
 import com.github.alexthe666.iceandfire.entity.EntityMyrmexBase;
 import com.github.alexthe666.iceandfire.entity.EntityMyrmexEgg;
 import com.github.alexthe666.iceandfire.entity.EntityMyrmexWorker;
+import com.github.alexthe666.iceandfire.entity.util.EntityUtil;
 import com.github.alexthe666.iceandfire.util.IAFMath;
 import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.entity.ai.goal.target.TargetGoal;
-import net.minecraft.world.entity.item.ItemEntity;
 import net.minecraft.world.phys.AABB;
 
-import java.util.Comparator;
+import javax.annotation.Nullable;
+import java.util.Collections;
 import java.util.EnumSet;
 import java.util.List;
 import java.util.function.Predicate;
 
-public class MyrmexAIPickupBabies<T extends ItemEntity> extends TargetGoal {
-    protected final DragonAITargetItems.Sorter theNearestAttackableTargetSorter;
+public class MyrmexAIPickupBabies extends TargetGoal {
     protected final Predicate<? super LivingEntity> targetEntitySelector;
     public EntityMyrmexWorker myrmex;
-    protected LivingEntity targetEntity;
+    protected @Nullable LivingEntity targetEntity;
 
     private List<LivingEntity> listBabies = IAFMath.emptyLivingEntityList;
 
     public MyrmexAIPickupBabies(EntityMyrmexWorker myrmex) {
         super(myrmex, false, false);
-        this.theNearestAttackableTargetSorter = new DragonAITargetItems.Sorter(myrmex);
-        this.targetEntitySelector = new Predicate<LivingEntity>() {
-            @Override
-            public boolean test(LivingEntity myrmex) {
-                return (myrmex instanceof EntityMyrmexBase && ((EntityMyrmexBase) myrmex).getGrowthStage() < 2
-                    && !((EntityMyrmexBase) myrmex).isInNursery()
-                    || myrmex instanceof EntityMyrmexEgg && !((EntityMyrmexEgg) myrmex).isInNursery());
-            }
-        };
+        this.targetEntitySelector = (Predicate<LivingEntity>) toCheck -> isYoungMyrmex(toCheck) || isMyrmexEgg(toCheck);
         this.myrmex = myrmex;
         this.setFlags(EnumSet.of(Flag.TARGET));
+    }
+
+    private boolean isYoungMyrmex(final Entity entity) {
+        return entity instanceof EntityMyrmexBase base && base.getGrowthStage() < 2 && !base.isInNursery();
+    }
+
+    private boolean isMyrmexEgg(final Entity entity) {
+        return entity instanceof EntityMyrmexEgg egg && !egg.isInNursery();
     }
 
     @Override
@@ -45,35 +45,45 @@ public class MyrmexAIPickupBabies<T extends ItemEntity> extends TargetGoal {
             return false;
         }
 
-        if (this.myrmex.level.getGameTime() % 4 == 0) // only update the list every 4 ticks
-            listBabies = this.mob.level.getEntitiesOfClass(LivingEntity.class, this.getTargetableArea(20), this.targetEntitySelector);
-
-        if (listBabies.isEmpty())
-            return false;
-
-        listBabies.sort(this.theNearestAttackableTargetSorter);
-        this.targetEntity = listBabies.get(0);
-        return true;
+        updateList(true);
+        return targetEntity != null;
     }
 
     protected AABB getTargetableArea(double targetDistance) {
         return this.mob.getBoundingBox().inflate(targetDistance, 4.0D, targetDistance);
     }
 
+    private void updateList(boolean forceNew) {
+        listBabies = EntityUtil.updateList(mob, forceNew ? null : listBabies, () -> this.mob.level.getEntitiesOfClass(LivingEntity.class, this.getTargetableArea(20), this.targetEntitySelector));
+        targetEntity = !listBabies.isEmpty() ? listBabies.get(0) : null;
+    }
+
     @Override
     public void start() {
-        this.mob.getNavigation().moveTo(this.targetEntity.getX(), this.targetEntity.getY(), this.targetEntity.getZ(), 1);
+        updateWantedPosition();
         super.start();
+    }
+
+    private void updateWantedPosition() {
+        if (targetEntity == null) {
+            stop();
+            return;
+        }
+
+        this.mob.getNavigation().moveTo(this.targetEntity.getX(), this.targetEntity.getY(), this.targetEntity.getZ(), 1);
     }
 
     @Override
     public void tick() {
         super.tick();
-        if (this.targetEntity != null && this.targetEntity.isAlive()
-            && this.mob.distanceToSqr(this.targetEntity) < 2) {
+
+        if (this.targetEntity != null && this.targetEntity.isAlive() && this.mob.distanceToSqr(this.targetEntity) < 2) {
             this.targetEntity.startRiding(this.myrmex);
+            stop();
+        } else if (!mob.getMoveControl().hasWanted()) {
+            updateList(false);
+            updateWantedPosition();
         }
-        stop();
     }
 
     @Override
@@ -81,18 +91,10 @@ public class MyrmexAIPickupBabies<T extends ItemEntity> extends TargetGoal {
         return !this.mob.getNavigation().isDone();
     }
 
-    public static class Sorter implements Comparator<Entity> {
-        private final Entity theEntity;
-
-        public Sorter(EntityMyrmexBase theEntityIn) {
-            this.theEntity = theEntityIn;
-        }
-
-        @Override
-        public int compare(Entity p_compare_1_, Entity p_compare_2_) {
-            final double d0 = this.theEntity.distanceToSqr(p_compare_1_);
-            final double d1 = this.theEntity.distanceToSqr(p_compare_2_);
-            return Double.compare(d0, d1);
-        }
+    @Override
+    public void stop() {
+        super.stop();
+        targetEntity = null;
+        listBabies = Collections.emptyList();
     }
 }

--- a/src/main/java/com/github/alexthe666/iceandfire/entity/ai/MyrmexAIPickupBabies.java
+++ b/src/main/java/com/github/alexthe666/iceandfire/entity/ai/MyrmexAIPickupBabies.java
@@ -8,7 +8,7 @@ import net.minecraft.world.entity.LivingEntity;
 
 public class MyrmexAIPickupBabies extends PickUpTargetGoal<EntityMyrmexWorker, LivingEntity> {
     public MyrmexAIPickupBabies(final EntityMyrmexWorker worker) {
-        super(worker, false, false, entity -> isYoungMyrmex(entity) || isMyrmexEgg(entity));
+        super(worker, false, false, entity -> isYoungMyrmex(entity) || isMyrmexEgg(entity), 1);
     }
 
     @Override

--- a/src/main/java/com/github/alexthe666/iceandfire/entity/ai/MyrmexAIStoreItems.java
+++ b/src/main/java/com/github/alexthe666/iceandfire/entity/ai/MyrmexAIStoreItems.java
@@ -1,6 +1,5 @@
 package com.github.alexthe666.iceandfire.entity.ai;
 
-import com.github.alexthe666.iceandfire.block.BlockMyrmexCocoon;
 import com.github.alexthe666.iceandfire.entity.EntityMyrmexBase;
 import com.github.alexthe666.iceandfire.entity.EntityMyrmexWorker;
 import com.github.alexthe666.iceandfire.entity.tile.TileEntityMyrmexCocoon;
@@ -13,21 +12,22 @@ import net.minecraft.core.BlockPos;
 import net.minecraft.world.InteractionHand;
 import net.minecraft.world.entity.ai.goal.Goal;
 import net.minecraft.world.item.ItemStack;
-import net.minecraft.world.level.block.entity.BlockEntity;
 
+import javax.annotation.Nullable;
 import java.util.ArrayList;
 import java.util.EnumSet;
 import java.util.List;
-import java.util.concurrent.ThreadLocalRandom;
 
 public class MyrmexAIStoreItems extends Goal {
+    private static final int DISTANCE_SQR = 12;
+
     private final EntityMyrmexBase myrmex;
     private final double movementSpeed;
     private BlockPos nextRoom = null;
     private BlockPos nextCocoon = null;
     private BlockPos mainRoom = null;
-    private boolean first = true; //first stage - enter the main hive room then storage room
-    private PathResult path;
+    private boolean shouldEnterMainRoom; // first stage - enter the main hive room then storage room
+    private PathResult<?> path;
 
     public MyrmexAIStoreItems(EntityMyrmexBase entityIn, double movementSpeedIn) {
         this.myrmex = entityIn;
@@ -40,126 +40,149 @@ public class MyrmexAIStoreItems extends Goal {
         if (!this.myrmex.canMove() || this.myrmex instanceof EntityMyrmexWorker && ((EntityMyrmexWorker) this.myrmex).holdingBaby() || !this.myrmex.shouldEnterHive() && !this.myrmex.getNavigation().isDone() || this.myrmex.getItemInHand(InteractionHand.MAIN_HAND).isEmpty()) {
             return false;
         }
+
         if (!(this.myrmex.getNavigation() instanceof AdvancedPathNavigate) || this.myrmex.isPassenger()) {
             return false;
         }
+
         if (this.myrmex.getWaitTicks() > 0) {
             return false;
         }
-        MyrmexHive village = this.myrmex.getHive();
-        if (village == null) {
-            return false;
-        }
-        if (!this.myrmex.isInHive()) {
-            return false;
-        }
-        first = true;
-        mainRoom = MyrmexHive.getGroundedPos(this.myrmex.level, village.getCenter());
 
-        nextRoom = MyrmexHive.getGroundedPos(this.myrmex.level, village.getRandomRoom(WorldGenMyrmexHive.RoomType.FOOD, this.myrmex.getRandom(), this.myrmex.blockPosition()));
-        nextCocoon = getNearbyCocoon(nextRoom);
-        if (nextCocoon == null) {
-            this.myrmex.setWaitTicks(20 + ThreadLocalRandom.current().nextInt(40));
-        }
-        this.path = ((AdvancedPathNavigate) this.myrmex.getNavigation()).moveToXYZ(mainRoom.getX() + 0.5D, mainRoom.getY() + 0.5D, mainRoom.getZ() + 0.5D, this.movementSpeed);
-        return nextCocoon != null;
-
+        return myrmex.isInHive();
     }
 
     @Override
     public boolean canContinueToUse() {
-        return !this.myrmex.getItemInHand(InteractionHand.MAIN_HAND).isEmpty() && nextCocoon != null && isUseableCocoon(nextCocoon) && !this.myrmex.isCloseEnoughToTarget(nextCocoon, 3) && this.myrmex.shouldEnterHive();
+        return isUseableCocoon(nextCocoon) && !this.myrmex.isCloseEnoughToTarget(nextCocoon, DISTANCE_SQR) && (myrmex.isInHive() || myrmex.shouldEnterHive());
+    }
+
+    @Override
+    public void start() {
+        super.start();
+        initialize();
+    }
+
+    private void initialize() {
+        MyrmexHive hive = myrmex.getHive();
+
+        if (hive == null) {
+            return;
+        }
+
+        mainRoom = MyrmexHive.getGroundedPos(this.myrmex.level, hive.getCenter());
+        nextRoom = MyrmexHive.getGroundedPos(this.myrmex.level, hive.getRandomRoom(WorldGenMyrmexHive.RoomType.FOOD, this.myrmex.getRandom(), this.myrmex.blockPosition()));
+        this.path = ((AdvancedPathNavigate) this.myrmex.getNavigation()).moveToXYZ(mainRoom.getX() + 0.5D, mainRoom.getY() + 0.5D, mainRoom.getZ() + 0.5D, this.movementSpeed);
     }
 
     @Override
     public void tick() {
-        if (first && mainRoom != null) {
-            if (this.myrmex.isCloseEnoughToTarget(mainRoom, 10)) {
-                this.path = ((AdvancedPathNavigate) this.myrmex.getNavigation()).moveToXYZ(nextCocoon.getX() + 0.5D, nextCocoon.getY() + 0.5D, nextCocoon.getZ() + 0.5D, this.movementSpeed);
-                first = false;
-            } else if (!this.myrmex.pathReachesTarget(path, mainRoom, 9)) {
-                //Simple way to stop executing this task
-                nextCocoon = null;
+        ItemStack stack = myrmex.getItemInHand(InteractionHand.MAIN_HAND);
+
+        if (stack.isEmpty()) {
+            stop();
+            return;
+        }
+
+        if (shouldEnterMainRoom && mainRoom != null) {
+            if (this.myrmex.isCloseEnoughToTarget(mainRoom, DISTANCE_SQR)) {
+                nextCocoonPath();
+                shouldEnterMainRoom = false;
+            } else if (!this.myrmex.pathReachesTarget(path, mainRoom, DISTANCE_SQR)) {
+                stop();
+                return;
             }
         }
 
-        if (!first && nextCocoon != null) {
-            final double dist = 9.0D; // 3 * 3
-            if (this.myrmex.isCloseEnoughToTarget(nextCocoon, dist) && !this.myrmex.getItemInHand(InteractionHand.MAIN_HAND).isEmpty() && isUseableCocoon(nextCocoon)) {
-                TileEntityMyrmexCocoon cocoon = (TileEntityMyrmexCocoon) this.myrmex.level.getBlockEntity(nextCocoon);
-                ItemStack itemstack = this.myrmex.getItemInHand(InteractionHand.MAIN_HAND);
-                if (!itemstack.isEmpty()) {
-                    for (int i = 0; i < cocoon.getContainerSize(); ++i) {
-                        if (!itemstack.isEmpty()) {
-                            ItemStack cocoonStack = cocoon.getItem(i);
-                            if (cocoonStack.isEmpty()) {
-                                cocoon.setItem(i, itemstack.copy());
-                                cocoon.setChanged();
+        if (nextCocoon == null && !shouldEnterMainRoom) {
+            stop();
+            return;
+        }
 
+        if (!shouldEnterMainRoom) {
+            if (this.myrmex.isCloseEnoughToTarget(nextCocoon, DISTANCE_SQR) && isUseableCocoon(nextCocoon)) {
+                TileEntityMyrmexCocoon cocoon = (TileEntityMyrmexCocoon) this.myrmex.level.getBlockEntity(nextCocoon);
+
+                for (int i = 0; i < cocoon.getContainerSize(); ++i) {
+                    if (!stack.isEmpty()) {
+                        ItemStack cocoonStack = cocoon.getItem(i);
+                        if (cocoonStack.isEmpty()) {
+                            cocoon.setItem(i, stack.copy());
+                            cocoon.setChanged();
+
+                            this.myrmex.setItemInHand(InteractionHand.MAIN_HAND, ItemStack.EMPTY);
+                            this.myrmex.isEnteringHive = false;
+                            return;
+                        } else if (cocoonStack.getItem() == stack.getItem()) {
+                            final int j = Math.min(cocoon.getMaxStackSize(), cocoonStack.getMaxStackSize());
+                            final int k = Math.min(stack.getCount(), j - cocoonStack.getCount());
+                            if (k > 0) {
+                                cocoonStack.grow(k);
+                                stack.shrink(k);
+
+                                if (stack.isEmpty()) {
+                                    cocoon.setChanged();
+                                }
                                 this.myrmex.setItemInHand(InteractionHand.MAIN_HAND, ItemStack.EMPTY);
                                 this.myrmex.isEnteringHive = false;
                                 return;
-                            } else if (cocoonStack.getItem() == itemstack.getItem()) {
-                                final int j = Math.min(cocoon.getMaxStackSize(), cocoonStack.getMaxStackSize());
-                                final int k = Math.min(itemstack.getCount(), j - cocoonStack.getCount());
-                                if (k > 0) {
-                                    cocoonStack.grow(k);
-                                    itemstack.shrink(k);
-
-                                    if (itemstack.isEmpty()) {
-                                        cocoon.setChanged();
-                                    }
-                                    this.myrmex.setItemInHand(InteractionHand.MAIN_HAND, ItemStack.EMPTY);
-                                    this.myrmex.isEnteringHive = false;
-                                    return;
-                                }
                             }
                         }
                     }
                 }
-            }
-            //In case the myrmex isn't close enough to the cocoon and walked to it's destination try a different one
-            else if (!this.myrmex.getItemInHand(InteractionHand.MAIN_HAND).isEmpty() && this.path.getStatus() == PathFindingStatus.COMPLETE && !this.myrmex.pathReachesTarget(path, nextCocoon, dist)) {
-                nextCocoon = getNearbyCocoon(nextRoom);
-                if (nextCocoon != null) {
-                    this.path = ((AdvancedPathNavigate) this.myrmex.getNavigation()).moveToXYZ(nextCocoon.getX() + 0.5D, nextCocoon.getY() + 0.5D, nextCocoon.getZ() + 0.5D, this.movementSpeed);
-                }
-            } else if (this.myrmex.pathReachesTarget(path, nextCocoon, dist) && this.path.isCancelled()) {
+            } else if (/* Arrived at cocoon but cannot reach target */ path.getStatus() == PathFindingStatus.COMPLETE && !myrmex.pathReachesTarget(path, nextCocoon, DISTANCE_SQR)) {
+                nextCocoonPath();
+            } else if (/* Something interrupted the task */ this.path.isCancelled() && this.myrmex.pathReachesTarget(path, nextCocoon, DISTANCE_SQR)) {
                 stop();
             }
         }
     }
 
+    private void nextCocoonPath() {
+        nextCocoon = getNearbyCocoon(nextRoom);
+
+        if (nextCocoon != null) {
+            path = ((AdvancedPathNavigate) this.myrmex.getNavigation()).moveToXYZ(nextCocoon.getX() + 0.5D, nextCocoon.getY() + 0.5D, nextCocoon.getZ() + 0.5D, this.movementSpeed);
+        }
+    }
+
     @Override
     public void stop() {
+        mainRoom = null;
         nextRoom = null;
         nextCocoon = null;
-        mainRoom = null;
-        first = true;
+        path = null;
     }
 
     public BlockPos getNearbyCocoon(BlockPos roomCenter) {
+        List<BlockPos> closeCocoons = new ArrayList<>();
         int RADIUS_XZ = 15;
         int RADIUS_Y = 7;
-        List<BlockPos> closeCocoons = new ArrayList<>();
-        BlockPos.betweenClosedStream(roomCenter.offset(-RADIUS_XZ, -RADIUS_Y, -RADIUS_XZ), roomCenter.offset(RADIUS_XZ, RADIUS_Y, RADIUS_XZ)).forEach(blockpos -> {
-            BlockEntity te = this.myrmex.level.getBlockEntity(blockpos);
-            if (te instanceof TileEntityMyrmexCocoon) {
-                if (!((TileEntityMyrmexCocoon) te).isFull(this.myrmex.getItemInHand(InteractionHand.MAIN_HAND))) {
-                    closeCocoons.add(te.getBlockPos());
-                }
+
+        BlockPos.betweenClosedStream(roomCenter.offset(-RADIUS_XZ, -RADIUS_Y, -RADIUS_XZ), roomCenter.offset(RADIUS_XZ, RADIUS_Y, RADIUS_XZ)).forEach(position -> {
+            if (isUseableCocoon(position)) {
+                closeCocoons.add(position);
             }
         });
+
         if (closeCocoons.isEmpty()) {
             return null;
         }
+
         return closeCocoons.get(myrmex.getRandom().nextInt(Math.max(closeCocoons.size() - 1, 1)));
     }
 
-    public boolean isUseableCocoon(BlockPos blockpos) {
-        if (this.myrmex.level.getBlockState(blockpos).getBlock() instanceof BlockMyrmexCocoon && this.myrmex.level.getBlockEntity(blockpos) != null && this.myrmex.level.getBlockEntity(blockpos) instanceof TileEntityMyrmexCocoon) {
-            return !((TileEntityMyrmexCocoon) this.myrmex.level.getBlockEntity(blockpos)).isFull(this.myrmex.getItemInHand(InteractionHand.MAIN_HAND));
+    public boolean isUseableCocoon(final @Nullable BlockPos position) {
+        if (position == null) {
+            return false;
         }
-        return false;
+
+        ItemStack stack = myrmex.getItemInHand(InteractionHand.MAIN_HAND);
+
+        if (stack.isEmpty()) {
+            return false;
+        }
+
+        return myrmex.getLevel().getBlockEntity(position) instanceof TileEntityMyrmexCocoon cocoon && !cocoon.isFull(stack);
     }
 }

--- a/src/main/java/com/github/alexthe666/iceandfire/entity/ai/PixieAIPickupItem.java
+++ b/src/main/java/com/github/alexthe666/iceandfire/entity/ai/PixieAIPickupItem.java
@@ -11,7 +11,7 @@ import net.minecraft.world.item.ItemStack;
 
 public class PixieAIPickupItem extends PickUpTargetGoal<EntityPixie, ItemEntity> {
     public PixieAIPickupItem(final EntityPixie pixie, boolean mustSee, boolean mustReach) {
-        super(pixie, mustSee, mustReach, item -> checkTamed(pixie, item) || checkUntamed(pixie, item));
+        super(pixie, mustSee, mustReach, item -> checkTamed(pixie, item) || checkUntamed(pixie, item), 1);
     }
 
     @Override

--- a/src/main/java/com/github/alexthe666/iceandfire/entity/ai/base/PickUpTargetGoal.java
+++ b/src/main/java/com/github/alexthe666/iceandfire/entity/ai/base/PickUpTargetGoal.java
@@ -68,6 +68,7 @@ public abstract class PickUpTargetGoal<M extends Mob, T extends Entity> extends 
         super.stop();
         currentTarget = null;
         targets = Collections.emptyList();
+        tickCount = 0;
     }
 
     @SuppressWarnings("unchecked")

--- a/src/main/java/com/github/alexthe666/iceandfire/entity/ai/base/PickUpTargetGoal.java
+++ b/src/main/java/com/github/alexthe666/iceandfire/entity/ai/base/PickUpTargetGoal.java
@@ -1,0 +1,111 @@
+package com.github.alexthe666.iceandfire.entity.ai.base;
+
+import com.github.alexthe666.iceandfire.entity.ai.DragonAITargetItems;
+import net.minecraft.world.entity.Entity;
+import net.minecraft.world.entity.Mob;
+import net.minecraft.world.entity.ai.goal.target.TargetGoal;
+import net.minecraft.world.phys.AABB;
+import org.jetbrains.annotations.NotNull;
+
+import javax.annotation.Nullable;
+import java.lang.reflect.ParameterizedType;
+import java.util.Collections;
+import java.util.EnumSet;
+import java.util.List;
+import java.util.function.Predicate;
+import java.util.function.Supplier;
+
+public abstract class PickUpTargetGoal<M extends Mob, T extends Entity> extends TargetGoal {
+    protected final Predicate<T> targetSelector;
+
+    protected @NotNull List<T> targets;
+    protected @Nullable T currentTarget;
+    protected int tickCount;
+    private final Class<T> rawTargetClass;
+    private final Supplier<List<T>> targetsSupplier;
+
+    @SuppressWarnings("unchecked")
+    public PickUpTargetGoal(final @NotNull M mob, boolean mustSee, boolean mustReach, final Predicate<T> targetSelector) {
+        super(mob, mustSee, mustReach);
+        this.targetSelector = targetSelector;
+        this.targets = Collections.emptyList();
+        this.rawTargetClass = (Class<T>) ((ParameterizedType) getClass().getGenericSuperclass()).getActualTypeArguments()[1];
+        this.targetsSupplier = () -> mob.getLevel().getEntitiesOfClass(rawTargetClass, getSearchArea(), targetSelector);
+        setFlags(EnumSet.of(Flag.TARGET));
+    }
+
+    @Override
+    public boolean canUse() {
+        return updateList();
+    }
+
+    @Override
+    public void start() {
+        super.start();
+        pickTarget();
+    }
+
+    @Override
+    public void tick() {
+        super.tick();
+        tickCount++;
+        updateList();
+        pickTarget();
+    }
+
+    @Override
+    public void stop() {
+        super.stop();
+        currentTarget = null;
+        targets = Collections.emptyList();
+    }
+
+    @SuppressWarnings("unchecked")
+    protected M getMob() {
+        return (M) mob;
+    }
+
+    protected AABB getSearchArea() {
+        double searchRange = getSearchRange();
+        return mob.getBoundingBox().inflate(searchRange, 4, searchRange);
+    }
+
+    protected boolean updateList() {
+        targets = updateList(getMob(), targets, targetsSupplier);
+        return !targets.isEmpty();
+    }
+
+    protected void pickTarget() {
+        if (currentTarget != null && !currentTarget.isAlive()) {
+            currentTarget = null;
+        }
+
+        if (currentTarget == null && !targets.isEmpty()) {
+            currentTarget = targets.get(0);
+        }
+
+        if (currentTarget != null) {
+            setMovement();
+        } else {
+            stop();
+        }
+    }
+
+    private List<T> updateList(final M mob, final List<T> targets, final Supplier<List<T>> targetsSupplier) {
+        List<T> result = targets;
+
+        if (tickCount % 20 == 0) {
+            result = targetsSupplier.get();
+            result.removeIf(Entity::isRemoved);
+        }
+
+        if (!result.isEmpty()) {
+            result.sort(new DragonAITargetItems.Sorter(mob));
+        }
+
+        return result;
+    }
+
+    abstract protected void setMovement();
+    abstract protected double getSearchRange();
+}

--- a/src/main/java/com/github/alexthe666/iceandfire/entity/ai/base/PickUpTargetGoal.java
+++ b/src/main/java/com/github/alexthe666/iceandfire/entity/ai/base/PickUpTargetGoal.java
@@ -42,7 +42,7 @@ public abstract class PickUpTargetGoal<M extends Mob, T extends Entity> extends 
 
     @Override
     public boolean canUse() {
-        if (chance != 1 && chance >= mob.getRandom().nextDouble()) {
+        if (chance != 1 && chance < mob.getRandom().nextDouble()) {
             return false;
         }
 

--- a/src/main/java/com/github/alexthe666/iceandfire/entity/util/EntityUtil.java
+++ b/src/main/java/com/github/alexthe666/iceandfire/entity/util/EntityUtil.java
@@ -2,14 +2,18 @@ package com.github.alexthe666.iceandfire.entity.util;
 
 import com.github.alexthe666.iceandfire.IceAndFire;
 import com.github.alexthe666.iceandfire.entity.EntityMutlipartPart;
+import com.github.alexthe666.iceandfire.entity.ai.DragonAITargetItems;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.util.Mth;
 import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.LivingEntity;
+import net.minecraft.world.entity.Mob;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
+import java.util.List;
 import java.util.UUID;
+import java.util.function.Supplier;
 
 public class EntityUtil {
     public static void updatePart(@Nullable final EntityMutlipartPart part, @NotNull final LivingEntity parent) {
@@ -35,5 +39,20 @@ public class EntityUtil {
         }
 
         part.setParent(parent);
+    }
+
+    public static <T extends Entity> List<T> updateList(final Mob mob, final List<T> list, final Supplier<List<T>> listSupplier) {
+        List<T> result = list;
+
+        if (list == null || mob.getLevel().getGameTime() % 4 == 0) {
+            result = listSupplier.get();
+            result.removeIf(Entity::isRemoved);
+        }
+
+        if (!result.isEmpty()) {
+            result.sort(new DragonAITargetItems.Sorter(mob));
+        }
+
+        return result;
     }
 }

--- a/src/main/java/com/github/alexthe666/iceandfire/entity/util/EntityUtil.java
+++ b/src/main/java/com/github/alexthe666/iceandfire/entity/util/EntityUtil.java
@@ -40,19 +40,4 @@ public class EntityUtil {
 
         part.setParent(parent);
     }
-
-    public static <T extends Entity> List<T> updateList(final Mob mob, final List<T> list, final Supplier<List<T>> listSupplier) {
-        List<T> result = list;
-
-        if (list == null || mob.getLevel().getGameTime() % 4 == 0) {
-            result = listSupplier.get();
-            result.removeIf(Entity::isRemoved);
-        }
-
-        if (!result.isEmpty()) {
-            result.sort(new DragonAITargetItems.Sorter(mob));
-        }
-
-        return result;
-    }
 }

--- a/src/main/java/com/github/alexthe666/iceandfire/entity/util/EntityUtil.java
+++ b/src/main/java/com/github/alexthe666/iceandfire/entity/util/EntityUtil.java
@@ -2,18 +2,15 @@ package com.github.alexthe666.iceandfire.entity.util;
 
 import com.github.alexthe666.iceandfire.IceAndFire;
 import com.github.alexthe666.iceandfire.entity.EntityMutlipartPart;
-import com.github.alexthe666.iceandfire.entity.ai.DragonAITargetItems;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.util.Mth;
 import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.LivingEntity;
-import net.minecraft.world.entity.Mob;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
-import java.util.List;
+import java.util.Comparator;
 import java.util.UUID;
-import java.util.function.Supplier;
 
 public class EntityUtil {
     public static void updatePart(@Nullable final EntityMutlipartPart part, @NotNull final LivingEntity parent) {
@@ -39,5 +36,19 @@ public class EntityUtil {
         }
 
         part.setParent(parent);
+    }
+
+    /** Sorts the entries so that the closest entity is at the first position */
+    public static class Sorter implements Comparator<Entity> {
+        private final Entity baseEntity;
+
+        public Sorter(final Entity baseEntity) {
+            this.baseEntity = baseEntity;
+        }
+
+        @Override
+        public int compare(final Entity firstEntity, final Entity secondEntity) {
+            return Double.compare(baseEntity.distanceToSqr(firstEntity), baseEntity.distanceToSqr(secondEntity));
+        }
     }
 }


### PR DESCRIPTION
Added custom pickup goal, used by
- pixie
- hippogryph
- myrmex worker
- cockatrice
- death worm
- ampithere

should fix #5187

Additionally:
- added logic to the previously empty add food effect method when dragons eat food (i.e. they should now gain the effects)
- removed `refreshDimensions` in `EntityMultiPart` because it was causing multiple seconds of delay when joining and leaving worlds (dimensions should only be refreshed when needed, not in a tick method)
- tried to adjust myrmex worker goal logic regarding storing items - didn't work (might be issue by the advanced pathfinding system since they simply don't move - they can see the cocoons and sometimes they get stuck at walls and move a bit once you break some blocks)
- made the check (whether a myrmex is inside a hive) more simple