### PR TITLE
dragon cave blacklist (hopefully just temp fix)

### DIFF
--- a/src/generated/resources/data/iceandfire/tags/worldgen/biome/blacklist/fire_dragon_cave.json
+++ b/src/generated/resources/data/iceandfire/tags/worldgen/biome/blacklist/fire_dragon_cave.json
@@ -1,0 +1,8 @@
+{
+  "values": [
+    {
+      "id": "#alexscaves:alexs_caves_biomes",
+      "required": false
+    }
+  ]
+}

--- a/src/generated/resources/data/iceandfire/tags/worldgen/biome/blacklist/fire_ice_cave.json
+++ b/src/generated/resources/data/iceandfire/tags/worldgen/biome/blacklist/fire_ice_cave.json
@@ -1,0 +1,8 @@
+{
+  "values": [
+    {
+      "id": "#alexscaves:alexs_caves_biomes",
+      "required": false
+    }
+  ]
+}

--- a/src/generated/resources/data/iceandfire/tags/worldgen/biome/blacklist/fire_lightning_cave.json
+++ b/src/generated/resources/data/iceandfire/tags/worldgen/biome/blacklist/fire_lightning_cave.json
@@ -1,0 +1,8 @@
+{
+  "values": [
+    {
+      "id": "#alexscaves:alexs_caves_biomes",
+      "required": false
+    }
+  ]
+}

--- a/src/main/java/com/github/alexthe666/iceandfire/IceAndFire.java
+++ b/src/main/java/com/github/alexthe666/iceandfire/IceAndFire.java
@@ -55,6 +55,8 @@ public class IceAndFire {
     public static CommonProxy PROXY = DistExecutor.safeRunForDist(() -> ClientProxy::new, () -> CommonProxy::new);
     private static int packetsRegistered = 0;
 
+    public static boolean ALEX_CAVES;
+
     static {
         NetworkRegistry.ChannelBuilder channel = NetworkRegistry.ChannelBuilder.named(new ResourceLocation("iceandfire", "main_channel"));
         String version = PROTOCOL_VERSION;
@@ -110,6 +112,8 @@ public class IceAndFire {
         modBus.addListener(this::setup);
         modBus.addListener(this::setupComplete);
         modBus.addListener(this::setupClient);
+
+        ALEX_CAVES = ModList.get().isLoaded("alexscaves");
     }
 
     @SubscribeEvent

--- a/src/main/java/com/github/alexthe666/iceandfire/datagen/IafBiomeTagGenerator.java
+++ b/src/main/java/com/github/alexthe666/iceandfire/datagen/IafBiomeTagGenerator.java
@@ -19,6 +19,10 @@ public class IafBiomeTagGenerator extends BiomeTagsProvider {
     public static final TagKey<Biome> HAS_MAUSOLEUM = TagKey.create(ForgeRegistries.BIOMES.getRegistryKey(), new ResourceLocation(IceAndFire.MODID, "has_structure/mausoleum"));
     public static final TagKey<Biome> HAS_GRAVEYARD = TagKey.create(ForgeRegistries.BIOMES.getRegistryKey(), new ResourceLocation(IceAndFire.MODID, "has_structure/graveyard"));
 
+    public static final TagKey<Biome> BLACKLIST_FIRE_DRAGON_CAVE = TagKey.create(ForgeRegistries.BIOMES.getRegistryKey(), new ResourceLocation(IceAndFire.MODID, "blacklist/fire_dragon_cave"));
+    public static final TagKey<Biome> BLACKLIST_ICE_DRAGON_CAVE = TagKey.create(ForgeRegistries.BIOMES.getRegistryKey(), new ResourceLocation(IceAndFire.MODID, "blacklist/fire_ice_cave"));
+    public static final TagKey<Biome> BLACKLIST_LIGHTNING_DRAGON_CAVE = TagKey.create(ForgeRegistries.BIOMES.getRegistryKey(), new ResourceLocation(IceAndFire.MODID, "blacklist/fire_lightning_cave"));
+
 
     public IafBiomeTagGenerator(PackOutput pOutput, CompletableFuture<HolderLookup.Provider> pProvider, @Nullable ExistingFileHelper existingFileHelper) {
         super(pOutput, pProvider, IceAndFire.MODID, existingFileHelper);
@@ -29,6 +33,10 @@ public class IafBiomeTagGenerator extends BiomeTagsProvider {
         tag(HAS_GRAVEYARD).addTag(BiomeTags.IS_OVERWORLD);
         tag(HAS_MAUSOLEUM).addTag(BiomeTags.IS_OVERWORLD);
         tag(HAS_GORGON_TEMPLE).addTag(BiomeTags.IS_OVERWORLD);
+
+        tag(BLACKLIST_FIRE_DRAGON_CAVE).addOptionalTag(new ResourceLocation("alexscaves", "alexs_caves_biomes"));
+        tag(BLACKLIST_ICE_DRAGON_CAVE).addOptionalTag(new ResourceLocation("alexscaves", "alexs_caves_biomes"));
+        tag(BLACKLIST_LIGHTNING_DRAGON_CAVE).addOptionalTag(new ResourceLocation("alexscaves", "alexs_caves_biomes"));
     }
 
     @Override

--- a/src/main/java/com/github/alexthe666/iceandfire/world/CustomBiomeFilter.java
+++ b/src/main/java/com/github/alexthe666/iceandfire/world/CustomBiomeFilter.java
@@ -1,11 +1,13 @@
 package com.github.alexthe666.iceandfire.world;
 
+import com.github.alexthe666.iceandfire.IceAndFire;
 import com.github.alexthe666.iceandfire.datagen.IafBiomeTagGenerator;
 import com.mojang.serialization.Codec;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Holder;
 import net.minecraft.tags.TagKey;
 import net.minecraft.util.RandomSource;
+import net.minecraft.world.level.WorldGenLevel;
 import net.minecraft.world.level.biome.Biome;
 import net.minecraft.world.level.levelgen.Heightmap;
 import net.minecraft.world.level.levelgen.placement.PlacedFeature;
@@ -46,7 +48,7 @@ public class CustomBiomeFilter extends PlacementFilter {
         TagKey<Biome> blacklist = blacklistReference.get();
         Holder<Biome> biome = context.getLevel().getBiome(position);
 
-        if (blacklist != null && biome.is(blacklist)) {
+        if (blacklist != null && (biome.is(blacklist) || /* Try to avoid Alex's Caves */ IceAndFire.ALEX_CAVES && isCloseToBlacklist(context.getLevel(), position, blacklist))) {
             // This is the underground biome (where the cave feature will actually be placed) - meaning if it's in the blacklist there is no need to do further checks
             return false;
         }
@@ -63,6 +65,14 @@ public class CustomBiomeFilter extends PlacementFilter {
         }
 
         return hasFeature;
+    }
+
+    /** Currently only called if Alex's Caves is present since otherwise it shouldn't really be relevant (and would just cost performance) */
+    private boolean isCloseToBlacklist(final WorldGenLevel level, final BlockPos position, final TagKey<Biome> blacklist) {
+        return level.getBiome(position.offset(32, 0, 32)).is(blacklist) ||
+                level.getBiome(position.offset(32, 0, -32)).is(blacklist) ||
+                level.getBiome(position.offset(-32, 0, 32)).is(blacklist) ||
+                level.getBiome(position.offset(-32, 0, -32)).is(blacklist);
     }
 
     public @NotNull PlacementModifierType<?> type() {

--- a/src/main/java/com/github/alexthe666/iceandfire/world/CustomBiomeFilter.java
+++ b/src/main/java/com/github/alexthe666/iceandfire/world/CustomBiomeFilter.java
@@ -1,14 +1,20 @@
 package com.github.alexthe666.iceandfire.world;
 
+import com.github.alexthe666.iceandfire.datagen.IafBiomeTagGenerator;
 import com.mojang.serialization.Codec;
 import net.minecraft.core.BlockPos;
+import net.minecraft.core.Holder;
+import net.minecraft.tags.TagKey;
 import net.minecraft.util.RandomSource;
+import net.minecraft.world.level.biome.Biome;
 import net.minecraft.world.level.levelgen.Heightmap;
 import net.minecraft.world.level.levelgen.placement.PlacedFeature;
 import net.minecraft.world.level.levelgen.placement.PlacementContext;
 import net.minecraft.world.level.levelgen.placement.PlacementFilter;
 import net.minecraft.world.level.levelgen.placement.PlacementModifierType;
 import org.jetbrains.annotations.NotNull;
+
+import java.util.concurrent.atomic.AtomicReference;
 
 /**
     Some worldgen mods / datapacks split biomes between cave and surface<br>
@@ -27,11 +33,33 @@ public class CustomBiomeFilter extends PlacementFilter {
 
     protected boolean shouldPlace(final PlacementContext context, @NotNull final RandomSource random, @NotNull final BlockPos position) {
         PlacedFeature placedfeature = context.topFeature().orElseThrow(() -> new IllegalStateException("Tried to biome check an unregistered feature, or a feature that should not restrict the biome"));
-        boolean hasFeature = context.generator().getBiomeGenerationSettings(context.getLevel().getBiome(position)).hasFeature(placedfeature);
+        AtomicReference<TagKey<Biome>> blacklistReference = new AtomicReference<>();
+
+        placedfeature.feature().unwrapKey().ifPresent(key -> {
+            switch (key.location().getPath()) {
+                case "fire_dragon_cave" -> blacklistReference.set(IafBiomeTagGenerator.BLACKLIST_FIRE_DRAGON_CAVE);
+                case "ice_dragon_cave" -> blacklistReference.set(IafBiomeTagGenerator.BLACKLIST_ICE_DRAGON_CAVE);
+                case "lightning_dragon_cave" -> blacklistReference.set(IafBiomeTagGenerator.BLACKLIST_LIGHTNING_DRAGON_CAVE);
+            };
+        });
+
+        TagKey<Biome> blacklist = blacklistReference.get();
+        Holder<Biome> biome = context.getLevel().getBiome(position);
+
+        if (blacklist != null && biome.is(blacklist)) {
+            // This is the underground biome (where the cave feature will actually be placed) - meaning if it's in the blacklist there is no need to do further checks
+            return false;
+        }
+
+        boolean hasFeature = context.generator().getBiomeGenerationSettings(biome).hasFeature(placedfeature);
 
         if (!hasFeature) {
-            // TODO :: In theory this could cause a fire dragon cave to spawn in an Terralith ice cave if said cave spawns below a desert or sth.
-            hasFeature = context.generator().getBiomeGenerationSettings(context.getLevel().getBiome(context.getLevel().getHeightmapPos(Heightmap.Types.WORLD_SURFACE_WG, position))).hasFeature(placedfeature);
+            biome = context.getLevel().getBiome(context.getLevel().getHeightmapPos(Heightmap.Types.WORLD_SURFACE_WG, position));
+            hasFeature = context.generator().getBiomeGenerationSettings(biome).hasFeature(placedfeature);
+
+            if (hasFeature && /* No need to check if the feature is not going to be placed anyway */ blacklist != null && biome.is(blacklist)) {
+                return false;
+            }
         }
 
         return hasFeature;


### PR DESCRIPTION
the biome config is responsible for adding features to the biomes

but the underground features (currently only dragon caves) also check the surface biome
(since some worldgen mods / datapacks split underground biome from surface biome)

this could mean that the feature generates in a biome which it shouldn't
this adds a tag where you can add biomes (for the three dragon cave types) which they should always avoid

2024-03-14
[iceandfire-2.1.13-1.20.1.zip](https://github.com/AlexModGuy/Ice_and_Fire/files/14608463/iceandfire-2.1.13-1.20.1.zip)
