### PR TITLE
[1.20] Edit ghost_chest.json loot table

### DIFF
--- a/src/main/resources/data/iceandfire/loot_tables/blocks/ghost_chest.json
+++ b/src/main/resources/data/iceandfire/loot_tables/blocks/ghost_chest.json
@@ -7,6 +7,12 @@
       "entries": [
         {
           "type": "minecraft:item",
+          "functions": [
+            {
+              "function": "minecraft:copy_name",
+              "source": "block_entity"
+            }
+          ],
           "name": "iceandfire:ghost_chest"
         }
       ],


### PR DESCRIPTION
## Goals
* Adds the `minecraft:copy_name` function to the ghost chest loot table to match vanilla's chest and barrel loot tables