### PR TITLE
[1.20] Properly load chunks to summon dragons

### DIFF
--- a/src/main/java/com/github/alexthe666/iceandfire/entity/EntityDragonBase.java
+++ b/src/main/java/com/github/alexthe666/iceandfire/entity/EntityDragonBase.java
@@ -2894,6 +2894,16 @@ public abstract class EntityDragonBase extends TamableAnimal implements IPassabi
     }
 
     @Override
+    public void onAddedToWorld() {
+        super.onAddedToWorld();
+
+        ItemSummoningCrystal itemSummoningCrystal = ItemSummoningCrystal.DELAYED_SUMMONS.get(this.getUUID());
+        if (itemSummoningCrystal != null) {
+            itemSummoningCrystal.delayedSummon();
+        }
+    }
+
+    @Override
     public int maxSearchNodes() {
         return (int) this.getAttribute(Attributes.FOLLOW_RANGE).getValue();
     }

--- a/src/main/java/com/github/alexthe666/iceandfire/item/ItemSummoningCrystal.java
+++ b/src/main/java/com/github/alexthe666/iceandfire/item/ItemSummoningCrystal.java
@@ -11,6 +11,7 @@ import net.minecraft.nbt.CompoundTag;
 import net.minecraft.network.chat.Component;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.sounds.SoundEvents;
+import net.minecraft.world.InteractionHand;
 import net.minecraft.world.InteractionResult;
 import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.LivingEntity;
@@ -21,28 +22,44 @@ import net.minecraft.world.item.TooltipFlag;
 import net.minecraft.world.item.context.UseOnContext;
 import net.minecraft.world.level.ChunkPos;
 import net.minecraft.world.level.Level;
+import net.minecraftforge.common.world.ForgeChunkManager;
 import org.jetbrains.annotations.NotNull;
 
 import javax.annotation.Nullable;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.UUID;
 
 public class ItemSummoningCrystal extends Item {
+    public static Map<UUID, ItemSummoningCrystal> DELAYED_SUMMONS = new HashMap<>();
 
+    private UUID dragonUuid;
+    private BlockPos dragonTargetPosition;
+    private float dragonTargetYaw;
+    private Player summoningPlayer;
+    private InteractionHand summoningHand;
+    private ServerLevel serverWorld;
+    private BlockPos dragonOriginPosition;
+    private ItemStack stack;
 
     public ItemSummoningCrystal() {
         super(new Item.Properties()/*.tab(IceAndFire.TAB_ITEMS)*/.stacksTo(1));
     }
 
-    public static boolean hasDragon(ItemStack stack) {
+    private static CompoundTag getDragonTag(ItemStack stack) {
         if (stack.getItem() instanceof ItemSummoningCrystal && stack.getTag() != null) {
             for (String tagInfo : stack.getTag().getAllKeys()) {
                 if (tagInfo.contains("Dragon")) {
-                    return true;
+                    return stack.getTag().getCompound(tagInfo);
                 }
             }
         }
-        return false;
+        return null;
+    }
+
+    public static boolean hasDragon(ItemStack stack) {
+        return getDragonTag(stack) != null;
     }
 
     @Override
@@ -88,95 +105,71 @@ public class ItemSummoningCrystal extends Item {
 
     @Override
     public @NotNull InteractionResult useOn(UseOnContext context) {
-        ItemStack stack = context.getPlayer().getItemInHand(context.getHand());
-        boolean flag = false;
-        BlockPos offsetPos = context.getClickedPos().relative(context.getClickedFace());
-        float yaw = context.getPlayer().getYRot();
-        boolean displayError = false;
-        if (stack.getItem() == this && hasDragon(stack)) {
-            int dragonCount = 0;
-            if (stack.getTag() != null) {
-                for (String tagInfo : stack.getTag().getAllKeys()) {
-                    if (tagInfo.contains("Dragon")) {
-                        dragonCount++;
-                        CompoundTag dragonTag = stack.getTag().getCompound(tagInfo);
-                        UUID id = dragonTag.getUUID("DragonUUID");
-                        if (id != null) {
-                            if (!context.getLevel().isClientSide) {
-                                try {
-                                    Entity entity = context.getLevel().getServer().getLevel(context.getPlayer().level().dimension()).getEntity(id);
-                                    if (entity != null) {
-                                        flag = true;
-                                        summonEntity(entity, context.getLevel(), offsetPos, yaw);
-                                    }
-                                } catch (Exception e) {
-                                    e.printStackTrace();
-                                    displayError = true;
-                                }
-                                // ForgeChunkManager.Ticket ticket = null;
-                                DragonPosWorldData data = DragonPosWorldData.get(context.getLevel());
-                                BlockPos dragonChunkPos = null;
-                                if (data != null) {
-                                    dragonChunkPos = data.getDragonPos(id);
-                                }
-                                if (IafConfig.chunkLoadSummonCrystal) {
-                                    try {
-                                        boolean flag2 = false;
-                                        if (!flag) {//server side but couldn't find dragon
-                                            if (data != null) {
-                                                if (context.getLevel().isClientSide) {
-                                                    ServerLevel serverWorld = (ServerLevel) context.getLevel();
-                                                    ChunkPos pos = new ChunkPos(dragonChunkPos);
-                                                    serverWorld.setChunkForced(pos.x, pos.z, true);
-                                                }
-                                                /*ticket = ForgeChunkManager.requestPlayerTicket(IceAndFire.INSTANCE, player.getName(), worldIn, ForgeChunkManager.Type.NORMAL);
-                                                if (ticket != null) {
-                                                    if (dragonChunkPos != null) {
-                                                        ForgeChunkManager.forceChunk(ticket, new ChunkPos(dragonChunkPos));
-                                                    } else {
-                                                        displayError = true;
-                                                    }
-                                                    lastChunkTicket = ticket;
-                                                    flag2 = true;
-                                                }*/
-                                            }
-                                        }
-                                        if (flag2) {
-                                            try {
-                                                Entity entity = context.getLevel().getServer().getLevel(context.getPlayer().level().dimension()).getEntity(id);
-                                                if (entity != null) {
-                                                    flag = true;
-                                                    summonEntity(entity, context.getLevel(), offsetPos, yaw);
-                                                }
-                                            } catch (Exception e) {
-                                                e.printStackTrace();
-                                            }
-                                        }
-                                       /* if (flag && lastChunkTicket != null && dragonChunkPos != null) {
-                                            ForgeChunkManager.releaseTicket(lastChunkTicket);
-                                            lastChunkTicket = null;
-                                        }*/
-                                    } catch (Exception e) {
-                                        IceAndFire.LOGGER.warn("Could not load chunk when summoning dragon");
-                                        e.printStackTrace();
-                                    }
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-            if (flag) {
-                context.getPlayer().playSound(SoundEvents.ENDERMAN_TELEPORT, 1, 1);
-                context.getPlayer().playSound(SoundEvents.GLASS_BREAK, 1, 1);
-                context.getPlayer().swing(context.getHand());
-                context.getPlayer().displayClientMessage(Component.translatable("message.iceandfire.dragonTeleport"), true);
-                stack.setTag(new CompoundTag());
-            } else if (displayError) {
-                context.getPlayer().displayClientMessage(Component.translatable("message.iceandfire.noDragonTeleport"), true);
-
-            }
+        if (context.getLevel().isClientSide) {
+            return InteractionResult.PASS;
         }
+
+        this.serverWorld = (ServerLevel) context.getLevel();
+        if (serverWorld.dimension() != Level.OVERWORLD) {
+            return InteractionResult.PASS;
+        }
+        this.summoningPlayer = context.getPlayer();
+        this.summoningHand = context.getHand();
+        this.stack = summoningPlayer.getItemInHand(summoningHand);
+        this.dragonTargetYaw = summoningPlayer.getYRot();
+        this.dragonTargetPosition = context.getClickedPos().relative(context.getClickedFace());
+
+        if (stack.getItem() != this) {
+            return InteractionResult.PASS;
+        }
+
+        CompoundTag dragonTag = getDragonTag(stack);
+        if (dragonTag == null) {
+            return InteractionResult.PASS;
+        }
+
+        this.dragonUuid = dragonTag.getUUID("DragonUUID");
+
+        IceAndFire.LOGGER.info("Trying to summon dragon {} {}", this.dragonUuid, dragonTag.getString("CustomName"));
+        Entity entity = serverWorld.getEntity(this.dragonUuid);
+        // If the dragon is already loaded, summon it immediately
+        if (entity != null) {
+            summonEntity(entity, this.serverWorld, this.dragonTargetPosition, this.dragonTargetYaw);
+            return InteractionResult.PASS;
+        }
+
+        // early exit if we are not allowed to load chunks to summon
+        if (!IafConfig.chunkLoadSummonCrystal) {
+            IceAndFire.LOGGER.info("Dragon entity {} not loaded, and chunk loading is disabled", this.dragonUuid);
+            this.displayClientError();
+            return InteractionResult.PASS;
+        }
+
+        DragonPosWorldData data = DragonPosWorldData.get(this.serverWorld);
+        if (data == null) {
+            IceAndFire.LOGGER.warn("Unable to load DragonPosWorldData for world {}", this.serverWorld);
+            this.displayClientError();
+            return InteractionResult.PASS;
+        }
+
+        this.dragonOriginPosition = data.getDragonPos(this.dragonUuid);
+
+        if (this.dragonOriginPosition == null) {
+            IceAndFire.LOGGER.warn("Summoning dragon origin position unknown for dragon {}", this.dragonUuid);
+            this.displayClientError();
+            return InteractionResult.PASS;
+        }
+
+        ChunkPos pos = new ChunkPos(this.dragonOriginPosition);
+        IceAndFire.LOGGER.info("Dragon entity not loaded, loading chunk {}", pos);
+
+        // try to load the chunk, and mark the entity to be summoned as soon as it gets added to the world
+        if (ForgeChunkManager.forceChunk(serverWorld, IceAndFire.MODID, this.summoningPlayer, pos.x, pos.z, true, false)) {
+            DELAYED_SUMMONS.put(this.dragonUuid, this);
+        } else {
+            IceAndFire.LOGGER.warn("Failed to force load chunk with Dragon {}", this.dragonUuid);
+        }
+
         return InteractionResult.PASS;
     }
 
@@ -191,7 +184,38 @@ public class ItemSummoningCrystal extends Item {
                 data.removeDragon(entity.getUUID());
             }
         }
+        this.summoningPlayer.playSound(SoundEvents.ENDERMAN_TELEPORT, 1, 1);
+        this.summoningPlayer.playSound(SoundEvents.GLASS_BREAK, 1, 1);
+        this.summoningPlayer.swing(this.summoningHand);
+        this.summoningPlayer.displayClientMessage(Component.translatable("message.iceandfire.dragonTeleport"), true);
+        stack.setTag(new CompoundTag());
     }
 
+    public void delayedSummon() {
+        DELAYED_SUMMONS.remove(this.dragonUuid);
+        try {
+            Entity entity = serverWorld.getEntity(this.dragonUuid);
+            if (entity != null) {
+                summonEntity(entity, this.serverWorld, this.dragonTargetPosition, this.dragonTargetYaw);
+                ChunkPos pos = new ChunkPos(this.dragonOriginPosition);
+                IceAndFire.LOGGER.info("Summoned dragon {} and unloading chunk {}", dragonUuid, pos);
+                ForgeChunkManager.forceChunk(this.serverWorld, IceAndFire.MODID, this.summoningPlayer, pos.x, pos.z, false, false);
+            }
+        } catch (Exception e) {
+            IceAndFire.LOGGER.warn("summoning error", e);
+            this.displayClientError();
+        } finally {
+            this.dragonUuid = null;
+            this.summoningPlayer = null;
+            this.summoningHand = null;
+            this.stack = null;
+            this.dragonTargetPosition = null;
+            this.serverWorld = null;
+            this.dragonOriginPosition = null;
+        }
+    }
 
+    private void displayClientError() {
+        summoningPlayer.displayClientMessage(Component.translatable("message.iceandfire.noDragonTeleport"), true);
+    }
 }

--- a/src/main/java/com/github/alexthe666/iceandfire/item/ItemSummoningCrystal.java
+++ b/src/main/java/com/github/alexthe666/iceandfire/item/ItemSummoningCrystal.java
@@ -42,6 +42,7 @@ public class ItemSummoningCrystal extends Item {
     private ServerLevel serverWorld;
     private BlockPos dragonOriginPosition;
     private ItemStack stack;
+    private long summoningTime = 0;
 
     public ItemSummoningCrystal() {
         super(new Item.Properties()/*.tab(IceAndFire.TAB_ITEMS)*/.stacksTo(1));
@@ -165,6 +166,7 @@ public class ItemSummoningCrystal extends Item {
 
         // try to load the chunk, and mark the entity to be summoned as soon as it gets added to the world
         if (ForgeChunkManager.forceChunk(serverWorld, IceAndFire.MODID, this.summoningPlayer, pos.x, pos.z, true, false)) {
+            this.summoningTime = serverWorld.getGameTime();
             DELAYED_SUMMONS.put(this.dragonUuid, this);
         } else {
             IceAndFire.LOGGER.warn("Failed to force load chunk with Dragon {}", this.dragonUuid);
@@ -193,26 +195,35 @@ public class ItemSummoningCrystal extends Item {
 
     public void delayedSummon() {
         DELAYED_SUMMONS.remove(this.dragonUuid);
-        try {
+        ChunkPos pos = new ChunkPos(this.dragonOriginPosition);
+
+        // make delayed summons expire if for some reason the chunk loading, or entity loading takes too long
+        // wouldn't want the dragon to summon minutes later at the original position
+        final long SUMMON_DELAY_TOLERANCE = 2_000;
+        if (this.serverWorld.getGameTime() - SUMMON_DELAY_TOLERANCE > this.summoningTime) {
+            IceAndFire.LOGGER.info("Dragon summon timed out for dragon {}; unloading chunk {}", dragonUuid, pos);
+        } else {
             Entity entity = serverWorld.getEntity(this.dragonUuid);
             if (entity != null) {
-                summonEntity(entity, this.serverWorld, this.dragonTargetPosition, this.dragonTargetYaw);
-                ChunkPos pos = new ChunkPos(this.dragonOriginPosition);
-                IceAndFire.LOGGER.info("Summoned dragon {} and unloading chunk {}", dragonUuid, pos);
-                ForgeChunkManager.forceChunk(this.serverWorld, IceAndFire.MODID, this.summoningPlayer, pos.x, pos.z, false, false);
+                if (this.summoningPlayer.isAlive()) {
+                    summonEntity(entity, this.serverWorld, this.dragonTargetPosition, this.dragonTargetYaw);
+                    IceAndFire.LOGGER.info("Summoned dragon {} and unloading chunk {}", dragonUuid, pos);
+                } else {
+                    IceAndFire.LOGGER.info("Player died since summoning {}; unloading chunk {}", dragonUuid, pos);
+                }
             }
-        } catch (Exception e) {
-            IceAndFire.LOGGER.warn("summoning error", e);
-            this.displayClientError();
-        } finally {
-            this.dragonUuid = null;
-            this.summoningPlayer = null;
-            this.summoningHand = null;
-            this.stack = null;
-            this.dragonTargetPosition = null;
-            this.serverWorld = null;
-            this.dragonOriginPosition = null;
         }
+
+        ForgeChunkManager.forceChunk(this.serverWorld, IceAndFire.MODID, this.summoningPlayer, pos.x, pos.z, false, false);
+
+        this.dragonUuid = null;
+        this.summoningPlayer = null;
+        this.summoningHand = null;
+        this.stack = null;
+        this.dragonTargetPosition = null;
+        this.serverWorld = null;
+        this.dragonOriginPosition = null;
+        this.summoningTime = 0;
     }
 
     private void displayClientError() {


### PR DESCRIPTION
Fixes #4468 for 1.20 branch

Entities don't get loaded immediately anymore in newer versions of Minecraft (introduced somewhere around 1.18 it seems) when forcing a chunk to load. In practice, it takes at least 1 tick, but often many more.