### PR TITLE
Bug Fix: Prevent players from breaking into mausoleums 

### DIFF
--- a/src/main/java/com/github/alexthe666/iceandfire/block/BlockDreadBase.java
+++ b/src/main/java/com/github/alexthe666/iceandfire/block/BlockDreadBase.java
@@ -42,6 +42,7 @@ public class BlockDreadBase extends BlockGeneric implements IDragonProof, IDread
 
     public BlockDreadBase(Properties props) {
         super(props);
+        this.registerDefaultState(this.stateDefinition.any().setValue(PLAYER_PLACED, Boolean.FALSE));
     }
 
     @SuppressWarnings("deprecation")


### PR DESCRIPTION
Simple fix—at some point in the previous adjustments to breakability of dread blocks, the default value of `player_placed` was removed from `BlockDreadBase`. This PR re-adds this in order to prevent players from breaking into mausoleums through `dread_stone_bricks` with a diamond pickaxe.

Other notes: This property _should_ be set by the state data in the structure template, but the `DreadRuinProcessor` seems to override this with default values when the stone brick variety is randomized. I don't have the expertise to know how/if these states should be merged somehow, but for now this change should fix a fairly game-breaking bug.